### PR TITLE
Add text selection mode and extract mouse handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    log_bench (0.1.3)
+    log_bench (0.1.4)
       curses (~> 1.5)
       lograge (~> 0.14)
       zeitwerk (~> 2.7)

--- a/lib/log_bench/app/main.rb
+++ b/lib/log_bench/app/main.rb
@@ -55,7 +55,7 @@ module LogBench
       end
 
       def setup_components
-        self.input_handler = InputHandler.new(state)
+        self.input_handler = InputHandler.new(state, screen)
         self.renderer = Renderer::Main.new(screen, state)
       end
 

--- a/lib/log_bench/app/mouse_handler.rb
+++ b/lib/log_bench/app/mouse_handler.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module LogBench
+  module App
+    class MouseHandler
+      include Curses
+
+      # UI constants
+      DEFAULT_VISIBLE_HEIGHT = 20
+
+      def initialize(state, screen)
+        self.state = state
+        self.screen = screen
+      end
+
+      def handle_mouse_input
+        with_warnings_suppressed do
+          mouse_event = getmouse
+
+          return unless mouse_event
+
+          if mouse_event.bstate & BUTTON1_CLICKED != 0
+            handle_mouse_click(mouse_event.x, mouse_event.y)
+          end
+        end
+      rescue
+        nil
+      end
+
+      private
+
+      attr_accessor :state, :screen
+
+      def handle_mouse_click(x, y)
+        if click_in_left_pane?(x, y)
+          # Switch to left pane if not already focused
+          state.switch_to_left_pane unless state.left_pane_focused?
+
+          # Convert click coordinates to request index
+          request_index = click_to_request_index(y)
+          return unless request_index
+
+          # Update selection
+          max_index = state.filtered_requests.size - 1
+          state.selected = [request_index, max_index].min
+          state.auto_scroll = false
+          state.adjust_scroll_for_selection(visible_height)
+        elsif click_in_right_pane?(x, y)
+          # Switch to right pane
+          state.switch_to_right_pane unless state.right_pane_focused?
+        end
+      end
+
+      def click_in_left_pane?(x, y)
+        # Left pane spans from x=0 to panel_width
+        # Header takes up first HEADER_HEIGHT lines
+        # Request list starts at HEADER_HEIGHT + 1 (accounting for border)
+        panel_width = screen.panel_width
+        header_height = 5 # Screen::HEADER_HEIGHT
+
+        x >= 0 && x < panel_width && y > header_height
+      end
+
+      def click_in_right_pane?(x, y)
+        # Right pane starts after left panel + border width
+        # From Screen: panel_width + PANEL_BORDER_WIDTH
+        panel_width = screen.panel_width
+        border_width = 3 # Screen::PANEL_BORDER_WIDTH
+        header_height = 5 # Screen::HEADER_HEIGHT
+
+        right_pane_start = panel_width + border_width
+
+        x >= right_pane_start && y > header_height
+      end
+
+      def click_to_request_index(y)
+        # Header takes up first 5 lines
+        # Request list has 1 line border at top, then 1 line for column headers
+        # So actual request rows start at y = 7 (5 header + 1 border + 1 column header)
+        header_height = 5
+        list_header_offset = 2 # border + column header
+
+        row_in_list = y - header_height - list_header_offset
+        return nil if row_in_list < 0
+
+        # Convert to actual request index accounting for scroll
+        state.scroll_offset + row_in_list
+      end
+
+      def visible_height
+        # Approximate visible height for calculations
+        DEFAULT_VISIBLE_HEIGHT
+      end
+
+      def with_warnings_suppressed
+        old_verbose = $VERBOSE
+        $VERBOSE = nil
+        yield
+      ensure
+        $VERBOSE = old_verbose
+      end
+    end
+  end
+end

--- a/lib/log_bench/app/renderer/header.rb
+++ b/lib/log_bench/app/renderer/header.rb
@@ -77,12 +77,14 @@ module LogBench
             header_win.attron(color_pair(3)) { header_win.addstr(state.auto_scroll ? "ON" : "OFF") }
             header_win.addstr(") | f:Filter | c:Clear filter | s:Sort(")
             header_win.attron(color_pair(3)) { header_win.addstr(state.sort.display_name) }
+            header_win.addstr(") | t:Text selection(")
+            header_win.attron(color_pair(3)) { header_win.addstr(state.text_selection_mode? ? "ON" : "OFF") }
             header_win.addstr(") | q:Quit")
           end
 
           header_win.setpos(3, 2)
           header_win.attron(A_DIM) do
-            header_win.addstr("←→/hl:Switch Pane | ↑↓/jk:Navigate | g/G:Top/End")
+            header_win.addstr("←→/hl:Switch Pane | ↑↓/jk/Click:Navigate | g/G:Top/End")
           end
         end
 

--- a/lib/log_bench/app/screen.rb
+++ b/lib/log_bench/app/screen.rb
@@ -29,6 +29,7 @@ module LogBench
         setup_colors
         clear_screen_immediately
         setup_windows
+        turn_text_selection_mode(false)
       end
 
       def cleanup
@@ -52,6 +53,10 @@ module LogBench
 
       def color_pair(n)
         Curses.color_pair(n)
+      end
+
+      def turn_text_selection_mode(enabled)
+        enabled ? mousemask(0) : mousemask(BUTTON1_CLICKED)
       end
 
       private

--- a/lib/log_bench/app/state.rb
+++ b/lib/log_bench/app/state.rb
@@ -4,7 +4,7 @@ module LogBench
   module App
     class State
       attr_reader :main_filter, :sort, :detail_filter
-      attr_accessor :requests, :auto_scroll, :scroll_offset, :selected, :detail_scroll_offset
+      attr_accessor :requests, :auto_scroll, :scroll_offset, :selected, :detail_scroll_offset, :text_selection_mode
 
       def initialize
         self.requests = []
@@ -14,6 +14,7 @@ module LogBench
         self.running = true
         self.focused_pane = :left
         self.detail_scroll_offset = 0
+        self.text_selection_mode = false
         self.main_filter = Filter.new
         self.detail_filter = Filter.new
         self.sort = Sort.new
@@ -29,6 +30,14 @@ module LogBench
 
       def toggle_auto_scroll
         self.auto_scroll = !auto_scroll
+      end
+
+      def toggle_text_selection_mode
+        self.text_selection_mode = !text_selection_mode
+      end
+
+      def text_selection_mode?
+        text_selection_mode
       end
 
       def clear_filter

--- a/lib/log_bench/version.rb
+++ b/lib/log_bench/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LogBench
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
- Add text selection toggle with 't' key to disable mouse for text selection
- Extract mouse handling logic to separate MouseHandler class
- Add mouse mask management in Screen class
- Update header to show text selection status and click navigation
- Fix InputHandler to accept screen parameter and remove Curses:: prefixes
- Add text_selection_mode state management
- Bump version to 0.1.4

This allows users to toggle between mouse navigation and text selection modes, improving usability for copying text from the TUI.