### PR TITLE
Add configuration for log_bench initialization message

### DIFF
--- a/lib/log_bench.rb
+++ b/lib/log_bench.rb
@@ -13,12 +13,25 @@ loader.setup
 module LogBench
   class Error < StandardError; end
 
-  # Parse log lines and return an array of entries
-  def self.parse(lines)
-    lines = [lines] if lines.is_a?(String)
+  class Configuration
+    attr_accessor :show_init_message
+  end
 
-    collection = Log::Collection.new(lines)
-    collection.requests
+  class << self
+    attr_accessor :configuration
+
+    # Parse log lines and return an array of entries
+    def parse(lines)
+      lines = [lines] if lines.is_a?(String)
+
+      collection = Log::Collection.new(lines)
+      collection.requests
+    end
+
+    def setup
+      self.configuration ||= Configuration.new
+      yield(configuration)
+    end
   end
 end
 

--- a/lib/log_bench/railtie.rb
+++ b/lib/log_bench/railtie.rb
@@ -2,7 +2,11 @@ require "rails/railtie"
 
 module LogBench
   class Railtie < Rails::Railtie
+    LINE = "=" * 70
+
     railtie_name :log_bench
+
+    config.log_bench = ActiveSupport::OrderedOptions.new
 
     # LogBench uses manual configuration (see README.md)
 
@@ -11,33 +15,63 @@ module LogBench
       load "tasks/log_bench.rake"
     end
 
+    initializer "log_bench.configure" do |app|
+      LogBench.setup do |config|
+        config.show_init_message = app.config.log_bench.show_init_message
+        config.show_init_message = :full if config.show_init_message.nil?
+      end
+    end
+
     # Show installation instructions when Rails starts in development
     initializer "log_bench.show_instructions", after: :load_config_initializers do
-      if Rails.env.development?
-        # Check if lograge is properly configured
-        puts "\n" + "=" * 70
-        puts "\n" + "=" * 70
-        if Rails.application.config.respond_to?(:lograge) &&
-            Rails.application.config.lograge.enabled
-          puts "✅ LogBench is ready to use!"
-          puts "=" * 70
-          puts "View your logs: log_bench log/development.log"
-        else
+      return unless Rails.env.development?
 
-          puts "🚀 LogBench is ready to configure!"
-          puts "=" * 70
-          puts "To start using LogBench:"
-          puts "  1. See README.md for configuration instructions"
-          puts "  2. Configure lograge in config/environments/development.rb"
-          puts "  3. Restart your Rails server"
-          puts "  4. Make some requests to generate logs"
-          puts "  5. View logs: log_bench log/development.log"
-          puts
+      # Check if lograge is properly configured
+      if Rails.application.config.respond_to?(:lograge) && Rails.application.config.lograge.enabled
+        if LogBench.configuration.show_init_message.eql? :full
+          print_full_init_message
+          print_help_instructions
+          puts LINE
+          puts LINE
+        elsif LogBench.configuration.show_init_message.eql? :min
+          print_min_init_message
         end
-        puts "For help: log_bench --help"
-        puts "=" * 70 + "\n"
-        puts "=" * 70 + "\n"
+      else
+        print_configuration_instructions
+        print_help_instructions
+        puts LINE
+        puts LINE
       end
+    end
+
+    private
+
+    def print_configuration_instructions
+      puts "🚀 LogBench is ready to configure!"
+      puts LINE
+      puts "To start using LogBench:"
+      puts "  1. See README.md for configuration instructions"
+      puts "  2. Configure lograge in config/environments/development.rb"
+      puts "  3. Restart your Rails server"
+      puts "  4. Make some requests to generate logs"
+      puts "  5. View logs: log_bench log/development.log"
+      puts ""
+    end
+
+    def print_min_init_message
+      puts "✅ LogBench is ready to use!"
+    end
+
+    def print_full_init_message
+      puts "\n" + LINE
+      puts "\n" + LINE
+      puts "✅ LogBench is ready to use!"
+      puts LINE
+      puts "View your logs: log_bench log/development.log"
+    end
+
+    def print_help_instructions
+      puts "For help: log_bench --help"
     end
   end
 end


### PR DESCRIPTION
The large configuration message is really helpful when first adding the gem to the project, but it becomes a bit noisy after time. It gets especially loud when using something like Foreman to fire up multiple processes (such as the Rails server + a Job runner).

This PR adds a `LogBench::Configuration` with a single attribute that controls the log output. The supported options are `:full` (default), `:min`, and `false`. Technically, anything that isn't `:full` or `:min` will get interpreted the same way as `false` with this implementation. There is no checking for valid options since it isn't really a mission critical configuration. Originally I had it as a simple on/off, but I realized that it's nice to have some message that log_bench is ready, rather than no message at all. Regardless of the setting, the message output is still disabled outside of `Rails.env.development?`.

I also added helper methods for the terminal output because the nested `if` statements became a bit difficult to read.

And lastly, because there is now an `attr_accessor` on the `LogBench` module, I changed the `self.[METHOD]` definitions to be inside a `class << self` block.

I did not add anything to the README about this, so if you like the change and want to merge it, let me know and I can add that as well! No worries if you're not a fan of this, or if you would prefer a more minimal amount of changes for the config. This is also the first time I've added config to a Gem, so it's possible that there are better ways to do it 🙂 