### PR TITLE
Simplify setup for users

### DIFF
--- a/lib/log_bench.rb
+++ b/lib/log_bench.rb
@@ -16,9 +16,8 @@ module LogBench
   extend LogBench::Parse
   extend LogBench::Setup
 
-  class << self
-    attr_accessor :configuration
-  end
+  singleton_class.attr_accessor :configuration
+  self.configuration = Configuration.new
 end
 
 # Load Railtie if Rails is available

--- a/lib/log_bench.rb
+++ b/lib/log_bench.rb
@@ -4,6 +4,7 @@ require "zeitwerk"
 require "json"
 require "time"
 require "curses"
+require "lograge"
 
 loader = Zeitwerk::Loader.for_gem
 loader.ignore("#{__dir__}/generators")

--- a/lib/log_bench/configuration.rb
+++ b/lib/log_bench/configuration.rb
@@ -8,5 +8,9 @@ module LogBench
       @show_init_message = :full
       @enable = true
     end
+
+    def enabled?
+      @enable
+    end
   end
 end

--- a/lib/log_bench/parse.rb
+++ b/lib/log_bench/parse.rb
@@ -3,7 +3,7 @@
 module LogBench
   module Parse
     def parse(lines)
-      lines = [lines] if lines.is_a?(String)
+      lines = Array(lines)
       collection = Log::Collection.new(lines)
       collection.requests
     end

--- a/lib/log_bench/railtie.rb
+++ b/lib/log_bench/railtie.rb
@@ -30,10 +30,7 @@ module LogBench
     end
 
     initializer "log_bench.configure" do |app|
-      LogBench.setup do |config|
-        config.show_init_message = app.config.log_bench.show_init_message || :full
-        config.enable = app.config.log_bench.enable || config.enable
-      end
+      # Not necessary any more.
     end
 
     # Show installation instructions when Rails starts in development

--- a/lib/log_bench/railtie.rb
+++ b/lib/log_bench/railtie.rb
@@ -39,6 +39,7 @@ module LogBench
     # Show installation instructions when Rails starts in development
     initializer "log_bench.show_instructions", after: :load_config_initializers do
       return unless Rails.env.development?
+      return unless LogBench.enabled?
 
       validate_lograge_config
     end

--- a/lib/log_bench/railtie.rb
+++ b/lib/log_bench/railtie.rb
@@ -31,8 +31,8 @@ module LogBench
 
     initializer "log_bench.configure" do |app|
       LogBench.setup do |config|
-        config.show_init_message = app.config.log_bench.show_init_message
-        config.show_init_message = :full if config.show_init_message.nil?
+        config.show_init_message = app.config.log_bench.show_init_message || :full
+        config.enable = app.config.log_bench.enable || config.enable
       end
     end
 

--- a/lib/log_bench/setup.rb
+++ b/lib/log_bench/setup.rb
@@ -21,17 +21,17 @@ module LogBench
       return unless defined?(Rails)
       return unless enabled?
 
-      Rails.application.configure do
-        config.lograge.enabled = true
-        config.lograge.formatter = Lograge::Formatters::Json.new
+      Rails.application.configure do |app|
+        app.config.lograge.enabled = true
+        app.config.lograge.formatter = Lograge::Formatters::Json.new
 
-        config.lograge.custom_options = lambda do |event|
+        app.config.lograge.custom_options = lambda do |event|
           event.payload[:params]&.except("controller", "action")
             .presence&.then { |p| {params: p} }
         end
 
-        config.logger ||= ActiveSupport::Logger.new(config.default_log_file)
-        config.logger.formatter = LogBench::JsonFormatter.new
+        app.config.logger ||= ActiveSupport::Logger.new(app.config.default_log_file)
+        app.config.logger.formatter = LogBench::JsonFormatter.new
       end
     end
   end

--- a/lib/log_bench/setup.rb
+++ b/lib/log_bench/setup.rb
@@ -3,7 +3,7 @@
 module LogBench
   module Setup
     def setup
-      return if @_already_setup
+      return raise "already setup" if @_already_setup
 
       yield(configuration) if block_given?
       configure_rails_logging

--- a/lib/log_bench/setup.rb
+++ b/lib/log_bench/setup.rb
@@ -3,7 +3,6 @@
 module LogBench
   module Setup
     def setup
-      self.configuration ||= Configuration.new
       yield(configuration)
     end
   end

--- a/lib/log_bench/setup.rb
+++ b/lib/log_bench/setup.rb
@@ -11,8 +11,15 @@ module LogBench
       @_already_setup = true
     end
 
+    def enabled?
+      configuration.enabled?
+    end
+
+    private
+
     def configure_rails_logging
       return unless defined?(Rails)
+      return unless enabled?
 
       Rails.application.configure do
         config.lograge.enabled = true

--- a/lib/log_bench/setup.rb
+++ b/lib/log_bench/setup.rb
@@ -3,7 +3,29 @@
 module LogBench
   module Setup
     def setup
-      yield(configuration)
+      return if @_already_setup
+
+      yield(configuration) if block_given?
+      configure_rails_logging
+
+      @_already_setup = true
+    end
+
+    def configure_rails_logging
+      return unless defined?(Rails)
+
+      Rails.application.configure do
+        config.lograge.enabled = true
+        config.lograge.formatter = Lograge::Formatters::Json.new
+
+        config.lograge.custom_options = lambda do |event|
+          event.payload[:params]&.except("controller", "action")
+            .presence&.then { |p| {params: p} }
+        end
+
+        config.logger ||= ActiveSupport::Logger.new(config.default_log_file)
+        config.logger.formatter = LogBench::JsonFormatter.new
+      end
     end
   end
 end


### PR DESCRIPTION
This PR makes it so all of setup step 1 is removed, and the configuration for `show_init_message` can be done in an initializer instead.