### PR TITLE
Unrequire `log_bench/version`

### DIFF
--- a/lib/log_bench.rb
+++ b/lib/log_bench.rb
@@ -4,7 +4,6 @@ require "zeitwerk"
 require "json"
 require "time"
 require "curses"
-require_relative "log_bench/version"
 
 loader = Zeitwerk::Loader.for_gem
 loader.ignore("#{__dir__}/generators")


### PR DESCRIPTION
We don't need to do this as `zeitwerk` takes care of this.