### PR TITLE
Fix crash when log entries have null or missing message content

### DIFF
--- a/lib/log_bench/log/entry.rb
+++ b/lib/log_bench/log/entry.rb
@@ -55,7 +55,7 @@ module LogBench
 
         self.timestamp = parse_timestamp(data["timestamp"])
         self.request_id = data["request_id"]
-        self.content = data["message"]
+        self.content = data["message"] || ""
         self.type = determine_json_type(data)
         true
       end

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -58,4 +58,16 @@ module TestFixtures
   def self.lograge_request_with_invalid_json_params
     '{"method":"GET","path":"/test","status":200,"duration":50.0,"controller":"TestController","action":"show","params":"{invalid json","request_id":"abc111","timestamp":"2025-01-01T10:04:00Z"}'
   end
+
+  def self.log_entry_with_null_message
+    '{"message":null,"request_id":"abc123","timestamp":"2025-01-01T10:05:00Z"}'
+  end
+
+  def self.log_entry_with_missing_message
+    '{"request_id":"abc123","timestamp":"2025-01-01T10:06:00Z"}'
+  end
+
+  def self.request_with_null_message_logs
+    [lograge_get_request, log_entry_with_null_message, log_entry_with_missing_message]
+  end
 end

--- a/test/test_log_bench.rb
+++ b/test/test_log_bench.rb
@@ -235,4 +235,22 @@ class TestLogBench < Minitest::Test
     assert_equal "Simple log message", parsed["message"]
     assert_equal "INFO", parsed["level"]
   end
+
+  def test_parse_entries_with_null_or_missing_message
+    collection = LogBench::Log::Collection.new(TestFixtures.request_with_null_message_logs)
+    requests = collection.requests
+
+    assert_equal 1, requests.size
+    request = requests.first
+
+    assert_equal 2, request.related_logs.size
+
+    request.related_logs.each do |log|
+      assert_equal "", log.content
+      refute_nil log.content
+    end
+
+    assert_equal :other, request.related_logs[0].type
+    assert_equal :other, request.related_logs[1].type
+  end
 end


### PR DESCRIPTION
# Fix crash when log entries have null or missing message content

## Problem

LogBench crashes with `undefined method 'match?' for nil` when trying to view request details that contain log entries with null or missing `message` fields.

### Error Details
```
❌ Error: undefined method `match?' for nil
/lib/log_bench/app/renderer/ansi.rb:14:in `has_ansi_codes?'
/lib/log_bench/app/renderer/details.rb:487:in `render_padded_text_with_spacing'
```

### Root Cause
Rails applications generate various types of log entries, including:
- Database migration logs
- Boot metrics reports  
- System configuration messages
- Custom logger entries

Some of these entries have JSON with `"message": null` or completely missing `message` fields. When LogBench tries to render these in the "Related Logs" section of the TUI, the ANSI renderer calls `.match?()` on `nil`, causing the crash.

## Steps to Reproduce

**Quick reproduction method:**
1. Add these log entries to any Rails log file:
```json
{"method":"GET","path":"/test","status":200,"duration":50.0,"request_id":"test123","timestamp":"2025-01-01T10:00:00Z"}
{"message":null,"request_id":"test123","timestamp":"2025-01-01T10:00:01Z"}
```

2. Run `log_bench path/to/logfile.log`
3. Navigate to the GET /test request and switch to the details pane
4. The TUI crashes when trying to render the related log with null message


## Solution

This PR fixes the issue at the source by ensuring `content` is never `nil` in log entries.

**Changed in `lib/log_bench/log/entry.rb` (line 58):**
```ruby
# Before
self.content = data["message"]

# After  
self.content = data["message"] || ""
```

### Why This Approach?

1. Prevents `nil` content from ever being created
2. One line fix vs multiple downstream guards
3. Consumers don't need to worry about `nil` content
4. Handles malformed log data gracefully
5. Doesn't break existing functionality

## Changes

### Files Modified:
- `lib/log_bench/log/entry.rb` - Core fix (1 line change)
- `test/support/fixtures.rb` - Test fixtures for edge cases
- `test/test_log_bench.rb` - Test case for null/missing message content

### Backward Compatibility
Fully backward compatible - All existing tests pass and functionality is preserved.

---

**Note**: This fix resolves the immediate crash issue. LogBench now gracefully handles log entries with missing message content by treating them as empty strings, allowing users to continue analyzing their logs without interruption.