### PR TITLE
Fix clipboard on linux wayland. Better sql query detecting

### DIFF
--- a/lib/log_bench/app/clipboard.rb
+++ b/lib/log_bench/app/clipboard.rb
@@ -12,6 +12,9 @@ module LogBench
         if system("which pbcopy > /dev/null 2>&1")
           # macOS
           IO.popen("pbcopy", "w") { |io| io.write(text) }
+        elsif system("which wl-copy > /dev/null 2>&1")
+          # Linux with wl-copy (wayland)
+          IO.popen("wl-copy", "w") { |io| io.write(text) }
         elsif system("which xclip > /dev/null 2>&1")
           # Linux with xclip
           IO.popen("xclip -selection clipboard", "w") { |io| io.write(text) }

--- a/lib/log_bench/app/copy_handler.rb
+++ b/lib/log_bench/app/copy_handler.rb
@@ -146,7 +146,8 @@ module LogBench
       def sql_query?(text)
         # Check for common SQL keywords that indicate this is a SQL query
         sql_keywords = %w[SELECT INSERT UPDATE DELETE TRANSACTION BEGIN COMMIT ROLLBACK SAVEPOINT]
-        sql_keywords.any? { |keyword| text.upcase.include?(keyword) }
+        pattern = /\b(#{sql_keywords.join('|')})\b/i
+        text.match?(pattern)
       end
     end
   end


### PR DESCRIPTION
I am on Omarchy and it uses Wayland compositor. `y` command didn't work and this PR should fix it.