### PR TITLE
Fix Array message handling in parser methods

### DIFF
--- a/lib/log_bench/log/call_line_entry.rb
+++ b/lib/log_bench/log/call_line_entry.rb
@@ -23,7 +23,7 @@ module LogBench
 
       def extract_from_json(data)
         super
-        message = data["message"] || ""
+        message = Parser.normalize_message(data["message"])
         return unless call_line_message?(data)
 
         self.content = message.strip
@@ -40,7 +40,7 @@ module LogBench
       end
 
       def call_line_message?(data)
-        message = data["message"] || ""
+        message = Parser.normalize_message(data["message"])
         message.include?("↳")
       end
     end

--- a/lib/log_bench/log/entry.rb
+++ b/lib/log_bench/log/entry.rb
@@ -9,7 +9,7 @@ module LogBench
         self.json_data = json_data
         self.timestamp = parse_timestamp(json_data["timestamp"])
         self.request_id = json_data["request_id"]
-        self.content = json_data["message"] || ""
+        self.content = Parser.normalize_message(json_data["message"])
         self.type = :other
       end
 

--- a/lib/log_bench/log/parser.rb
+++ b/lib/log_bench/log/parser.rb
@@ -83,28 +83,42 @@ module LogBench
         data["method"] && data["path"] && data["status"]
       end
 
+      def self.normalize_message(message)
+        case message
+        when String
+          message
+        when Array
+          message.join(" ")
+        when NilClass
+          ""
+        else
+          message.to_s
+        end
+      end
+
       def self.sql_message?(data)
-        message = data["message"] || ""
+        message = normalize_message(data["message"])
         %w[SELECT INSERT UPDATE DELETE TRANSACTION BEGIN COMMIT ROLLBACK SAVEPOINT].any? { |op| message.include?(op) }
       end
 
       def self.cache_message?(data)
-        message = data["message"] || ""
+        message = normalize_message(data["message"])
         message.include?("CACHE")
       end
 
       def self.call_stack_message?(data)
-        message = data["message"] || ""
+        message = normalize_message(data["message"])
         message.include?("↳")
       end
 
       def self.job_enqueue_message?(data)
-        message = data["message"] || ""
+        message = normalize_message(data["message"])
         message.match?(/Enqueued .+ \(Job ID: .+\)/)
       end
 
       def self.extract_job_id_from_enqueue(message)
-        match = message.match(/Job ID: ([^\)]+)/)
+        normalized_message = normalize_message(message)
+        match = normalized_message.match(/Job ID: ([^\)]+)/)
         match[1] if match
       end
 


### PR DESCRIPTION
## Problem

log_bench was crashing with the following error when encountering log entries where the `message` field was an Array instead of a String:

```
Error: undefined method 'match?' for an instance of Array

/ruby/3.4.7/lib/ruby/gems/3.4.0/gems/log_bench-0.5.2/lib/log_bench/log/parser.rb:103:in 'LogBench::Log::Parser.job_enqueue_message?'
/ruby/3.4.7/lib/ruby/gems/3.4.0/gems/log_bench-0.5.2/lib/log_bench/log/parser.rb:77:in 'LogBench::Log::Parser.determine_json_type'
/ruby/3.4.7/lib/ruby/gems/3.4.0/gems/log_bench-0.5.2/lib/log_bench/log/parser.rb:31:in 'LogBench::Log::Parser.build_specific_entry'
/ruby/3.4.7/lib/ruby/gems/3.4.0/gems/log_bench-0.5.2/lib/log_bench/log/parser.rb:13:in 'LogBench::Log::Parser.parse_line'
/ruby/3.4.7/lib/ruby/gems/3.4.0/gems/log_bench-0.5.2/lib/log_bench/log/parser.rb:22:in 'block in LogBench::Log::Parser.parse_lines'
/ruby/3.4.7/lib/ruby/gems/3.4.0/gems/log_bench-0.5.2/lib/log_bench/log/parser.rb:22:in 'Array#map'
/ruby/3.4.7/lib/ruby/gems/3.4.0/gems/log_bench-0.5.2/lib/log_bench/log/parser.rb:22:in 'LogBench::Log::Parser.parse_lines'
/ruby/3.4.7/lib/ruby/gems/3.4.0/gems/log_bench-0.5.2/lib/log_bench/log/collection.rb:73:in 'LogBench::Log::Collection#parse_input'
/ruby/3.4.7/lib/ruby/gems/3.4.0/gems/log_bench-0.5.2/lib/log_bench/log/collection.rb:12:in 'LogBench::Log::Collection#initialize'
/ruby/3.4.7/lib/ruby/gems/3.4.0/gems/log_bench-0.5.2/lib/log_bench/log/file.rb:44:in 'Class#new'
/ruby/3.4.7/lib/ruby/gems/3.4.0/gems/log_bench-0.5.2/lib/log_bench/log/file.rb:44:in 'LogBench::Log::File#collection'
/ruby/3.4.7/lib/ruby/gems/3.4.0/gems/log_bench-0.5.2/lib/log_bench/log/file.rb:16:in 'LogBench::Log::File#requests'
/ruby/3.4.7/lib/ruby/gems/3.4.0/gems/log_bench-0.5.2/lib/log_bench/app/main.rb:71:in 'LogBench::App::Main#load_initial_data'
/ruby/3.4.7/lib/ruby/gems/3.4.0/gems/log_bench-0.5.2/lib/log_bench/app/main.rb:29:in 'LogBench::App::Main#run'
/ruby/3.4.7/lib/ruby/gems/3.4.0/gems/log_bench-0.5.2/exe/log_bench:61:in '<top (required)>'
/ruby/3.4.7/bin/log_bench:25:in 'Kernel#load'
/ruby/3.4.7/bin/log_bench:25:in '<main>'
```

### Root Cause

The parser methods (`sql_message?`, `cache_message?`, `call_stack_message?`, `job_enqueue_message?`) were calling String methods like `match?()` and `include?()` directly on `data["message"]` without checking if it was actually a String. Some logging libraries may output the `message` field as an Array, causing these methods to fail.

## Solution

Added a `normalize_message()` helper method that safely converts various input types to a String:

- **String**: Returns as-is
- **Array**: Joins elements with spaces
- **nil**: Returns empty string
- **Other types**: Converts to string using `to_s`

All message detection methods now use this helper to ensure they always receive a String, preventing the `match?` error.

## Changes

- ✅ Added `normalize_message()` helper method to `LogBench::Log::Parser`
- ✅ Updated `sql_message?()` to use normalized messages
- ✅ Updated `cache_message?()` to use normalized messages
- ✅ Updated `call_stack_message?()` to use normalized messages
- ✅ Updated `job_enqueue_message?()` to use normalized messages
- ✅ Updated `extract_job_id_from_enqueue()` to handle Array messages
- ✅ Updated `Entry#initialize` to normalize messages when setting content
- ✅ Updated `CallLineEntry` to use normalized messages
- ✅ Added comprehensive test coverage for Array message handling

## Testing

Added tests covering:
- `normalize_message()` with String, Array, nil, and other types
- All message detection methods with Array messages
- End-to-end parsing of log entries with Array messages
- Job enqueue detection and extraction with Array messages

All existing tests continue to pass, ensuring backward compatibility.

## Impact

This fix ensures log_bench works correctly with log formats that use Array messages. The change is backward compatible - String messages continue to work as before.

