### PR TITLE
Add column filter row with operator-aware filtering

### DIFF
--- a/lib/log_bench/app/input_handler.rb
+++ b/lib/log_bench/app/input_handler.rb
@@ -16,6 +16,7 @@ module LogBench
       CTRL_R = 18         # Undo clear requests (restore)
       ESC = 27            # Escape
       BACKSPACE_KEYS = [127, 8, KEY_BACKSPACE].freeze
+      SHIFT_TAB_KEYS = [353, defined?(KEY_BTAB) && KEY_BTAB].compact.uniq.freeze
       EXIT_FILTER_MODE_KEYS = [27, 10, 13].freeze # Escape, Enter, Return
 
       # UI constants
@@ -66,6 +67,10 @@ module LogBench
         case ch
         when *EXIT_FILTER_MODE_KEYS
           state.exit_filter_mode
+        when KEY_LEFT, *SHIFT_TAB_KEYS
+          handle_filter_left_navigation
+        when KEY_RIGHT, TAB
+          handle_filter_right_navigation
         when KEY_UP
           state.exit_filter_mode
           state.navigate_up
@@ -76,6 +81,18 @@ module LogBench
           state.backspace_filter
         else
           add_character_to_filter(ch)
+        end
+      end
+
+      def handle_filter_left_navigation
+        if state.filter_mode
+          state.previous_request_filter_column
+        end
+      end
+
+      def handle_filter_right_navigation
+        if state.filter_mode
+          state.next_request_filter_column
         end
       end
 

--- a/lib/log_bench/app/mouse_handler.rb
+++ b/lib/log_bench/app/mouse_handler.rb
@@ -143,23 +143,11 @@ module LogBench
       end
 
       def request_filter_column_for_x(x)
-        start_x = Renderer::RequestList::HEADER_Y_OFFSET
-        method_width = Renderer::RequestList::METHOD_WIDTH
-        filter_right_edge = screen.panel_width - Renderer::RequestList::FILTER_RIGHT_EDGE_OFFSET
-
-        path_start = start_x + method_width
-        time_width = Renderer::RequestList::FILTER_TIME_WIDTH
-        status_width = Renderer::RequestList::FILTER_STATUS_WIDTH
-        time_start = filter_right_edge - time_width
-        status_start = time_start - status_width
-        path_width = [status_start - path_start, 1].max
-
-        ranges = [
-          [:method, start_x...(start_x + method_width)],
-          [:path, path_start...(path_start + path_width)],
-          [:status, status_start...(status_start + status_width)],
-          [:time, time_start...(time_start + time_width)]
-        ]
+        ranges = Renderer::RequestFilterBar.layout(
+          screen.panel_width,
+          header_x_offset: Renderer::RequestList::HEADER_Y_OFFSET,
+          method_width: Renderer::RequestList::METHOD_WIDTH
+        ).slice(:method, :path, :status, :time)
 
         ranges.each do |column, range|
           return column if range.cover?(x)

--- a/lib/log_bench/app/mouse_handler.rb
+++ b/lib/log_bench/app/mouse_handler.rb
@@ -33,6 +33,11 @@ module LogBench
           # Switch to left pane if not already focused
           state.switch_to_left_pane unless state.left_pane_focused?
 
+          if click_on_column_header_row?(y)
+            handle_request_header_click(x)
+            return
+          end
+
           if click_on_request_filter_row?(y)
             handle_request_filter_click(x)
             return
@@ -94,6 +99,40 @@ module LogBench
 
       def click_on_request_filter_row?(y)
         y == screen_header_height + Renderer::RequestList::FILTER_ROW_Y
+      end
+
+      def click_on_column_header_row?(y)
+        y == screen_header_height + Renderer::RequestList::COLUMN_HEADER_Y
+      end
+
+      def handle_request_header_click(x)
+        selected_column = request_header_column_for_x(x)
+        state.toggle_request_sort(selected_column) if selected_column
+      end
+
+      def request_header_column_for_x(x)
+        start_x = Renderer::RequestList::HEADER_Y_OFFSET
+        method_width = Renderer::RequestList::METHOD_WIDTH
+        path_width = screen.panel_width - Renderer::RequestList::PATH_MARGIN
+        status_width = Renderer::RequestList::STATUS_WIDTH
+
+        method_start = start_x
+        path_start = method_start + method_width
+        status_start = path_start + path_width
+        time_start = status_start + status_width
+
+        ranges = [
+          [:method, method_start...(method_start + method_width)],
+          [nil, path_start...(path_start + path_width)],
+          [:status, status_start...(status_start + status_width)],
+          [:time, time_start...screen.panel_width]
+        ]
+
+        ranges.each do |column, range|
+          return column if range.cover?(x)
+        end
+
+        nil
       end
 
       def handle_request_filter_click(x)

--- a/lib/log_bench/app/mouse_handler.rb
+++ b/lib/log_bench/app/mouse_handler.rb
@@ -5,9 +5,6 @@ module LogBench
     class MouseHandler
       include Curses
 
-      # UI constants
-      DEFAULT_VISIBLE_HEIGHT = 20
-
       def initialize(state, screen)
         self.state = state
         self.screen = screen
@@ -36,6 +33,11 @@ module LogBench
           # Switch to left pane if not already focused
           state.switch_to_left_pane unless state.left_pane_focused?
 
+          if click_on_request_filter_row?(y)
+            handle_request_filter_click(x)
+            return
+          end
+
           # Convert click coordinates to request index
           request_index = click_to_request_index(y)
           return unless request_index
@@ -60,7 +62,7 @@ module LogBench
         # Header takes up first HEADER_HEIGHT lines
         # Request list starts at HEADER_HEIGHT + 1 (accounting for border)
         panel_width = screen.panel_width
-        header_height = 5 # Screen::HEADER_HEIGHT
+        header_height = Screen::HEADER_HEIGHT
 
         x >= 0 && x < panel_width && y > header_height
       end
@@ -69,8 +71,8 @@ module LogBench
         # Right pane starts after left panel + border width
         # From Screen: panel_width + PANEL_BORDER_WIDTH
         panel_width = screen.panel_width
-        border_width = 3 # Screen::PANEL_BORDER_WIDTH
-        header_height = 5 # Screen::HEADER_HEIGHT
+        border_width = Screen::PANEL_BORDER_WIDTH
+        header_height = Screen::HEADER_HEIGHT
 
         right_pane_start = panel_width + border_width
 
@@ -78,11 +80,10 @@ module LogBench
       end
 
       def click_to_request_index(y)
-        # Header takes up first 5 lines
-        # Request list has 1 line border at top, then 1 line for column headers
-        # So actual request rows start at y = 7 (5 header + 1 border + 1 column header)
-        header_height = 5
-        list_header_offset = 2 # border + column header
+        # Header takes up first 5 lines.
+        # Request list rows start at RequestList::ROWS_START_Y inside log_win.
+        header_height = screen_header_height
+        list_header_offset = Renderer::RequestList::ROWS_START_Y
 
         row_in_list = y - header_height - list_header_offset
         return nil if row_in_list < 0
@@ -91,9 +92,45 @@ module LogBench
         state.scroll_offset + row_in_list
       end
 
-      def visible_height
-        # Approximate visible height for calculations
-        DEFAULT_VISIBLE_HEIGHT
+      def click_on_request_filter_row?(y)
+        y == screen_header_height + Renderer::RequestList::FILTER_ROW_Y
+      end
+
+      def handle_request_filter_click(x)
+        selected_column = request_filter_column_for_x(x)
+        state.exit_filter_mode
+        state.select_request_filter_column(selected_column) if selected_column
+        state.enter_filter_mode
+      end
+
+      def request_filter_column_for_x(x)
+        start_x = Renderer::RequestList::HEADER_Y_OFFSET
+        method_width = Renderer::RequestList::METHOD_WIDTH
+        filter_right_edge = screen.panel_width - Renderer::RequestList::FILTER_RIGHT_EDGE_OFFSET
+
+        path_start = start_x + method_width
+        time_width = Renderer::RequestList::FILTER_TIME_WIDTH
+        status_width = Renderer::RequestList::FILTER_STATUS_WIDTH
+        time_start = filter_right_edge - time_width
+        status_start = time_start - status_width
+        path_width = [status_start - path_start, 1].max
+
+        ranges = [
+          [:method, start_x...(start_x + method_width)],
+          [:path, path_start...(path_start + path_width)],
+          [:status, status_start...(status_start + status_width)],
+          [:time, time_start...(time_start + time_width)]
+        ]
+
+        ranges.each do |column, range|
+          return column if range.cover?(x)
+        end
+
+        nil
+      end
+
+      def screen_header_height
+        Screen::HEADER_HEIGHT
       end
 
       def with_warnings_suppressed

--- a/lib/log_bench/app/renderer/ansi.rb
+++ b/lib/log_bench/app/renderer/ansi.rb
@@ -5,6 +5,25 @@ module LogBench
     module Renderer
       class Ansi
         include Curses
+        BRIGHT_WHITE = Screen::BRIGHT_WHITE
+        BLACK = Screen::BLACK
+        ERROR_RED = Screen::ERROR_RED
+        SUCCESS_GREEN = Screen::SUCCESS_GREEN
+        WARNING_YELLOW = Screen::WARNING_YELLOW
+        INFO_BLUE = Screen::INFO_BLUE
+        MAGENTA = Screen::MAGENTA
+        HEADER_CYAN = Screen::HEADER_CYAN
+
+        ANSI_RESET = 0
+        ANSI_BOLD = 1
+        ANSI_BLACK = 30
+        ANSI_RED = 31
+        ANSI_GREEN = 32
+        ANSI_YELLOW = 33
+        ANSI_BLUE = 34
+        ANSI_MAGENTA = 35
+        ANSI_CYAN = 36
+        ANSI_WHITE = 37
 
         def initialize(screen)
           self.screen = screen
@@ -166,20 +185,20 @@ module LogBench
 
         def ansi_to_curses_color(codes)
           # Convert ANSI color codes to curses color pairs
-          return nil if codes.empty? || codes == [0]
+          return nil if codes.empty? || codes == [ANSI_RESET]
 
           # Handle common ANSI codes
           codes.each do |code|
             case code
-            when 1 then return color_pair(7) | A_BOLD  # Bold/bright
-            when 30 then return color_pair(8) # Black
-            when 31 then return color_pair(6) # Red
-            when 32 then return color_pair(3) # Green
-            when 33 then return color_pair(4) # Yellow
-            when 34 then return color_pair(5) # Blue
-            when 35 then return color_pair(9) # Magenta
-            when 36 then return color_pair(1) # Cyan
-            when 37 then return nil           # White (default)
+            when ANSI_BOLD then return color_pair(BRIGHT_WHITE) | A_BOLD
+            when ANSI_BLACK then return color_pair(BLACK)
+            when ANSI_RED then return color_pair(ERROR_RED)
+            when ANSI_GREEN then return color_pair(SUCCESS_GREEN)
+            when ANSI_YELLOW then return color_pair(WARNING_YELLOW)
+            when ANSI_BLUE then return color_pair(INFO_BLUE)
+            when ANSI_MAGENTA then return color_pair(MAGENTA)
+            when ANSI_CYAN then return color_pair(HEADER_CYAN)
+            when ANSI_WHITE then return nil
             end
           end
 

--- a/lib/log_bench/app/renderer/details.rb
+++ b/lib/log_bench/app/renderer/details.rb
@@ -9,6 +9,13 @@ module LogBench
         include Curses
         EMPTY_LINE = {text: "", color: nil}
         SEPARATOR_LINE = {text: "", color: nil, separator: true}
+        HEADER_CYAN = Screen::HEADER_CYAN
+        DEFAULT_WHITE = Screen::DEFAULT_WHITE
+        SUCCESS_GREEN = Screen::SUCCESS_GREEN
+        WARNING_YELLOW = Screen::WARNING_YELLOW
+        INFO_BLUE = Screen::INFO_BLUE
+        ERROR_RED = Screen::ERROR_RED
+        SELECTION_HIGHLIGHT = Screen::SELECTION_HIGHLIGHT
 
         def initialize(screen, state, scrollbar, ansi_renderer)
           self.screen = screen
@@ -54,9 +61,9 @@ module LogBench
           detail_win.setpos(0, 2)
 
           if state.right_pane_focused?
-            detail_win.attron(color_pair(1) | A_BOLD) { detail_win.addstr(" Request Details ") }
+            detail_win.attron(color_pair(HEADER_CYAN) | A_BOLD) { detail_win.addstr(" Request Details ") }
           else
-            detail_win.attron(color_pair(2) | A_DIM) { detail_win.addstr(" Request Details ") }
+            detail_win.attron(color_pair(DEFAULT_WHITE) | A_DIM) { detail_win.addstr(" Request Details ") }
           end
 
           # Show detail filter to the right of the title (always visible when active)
@@ -67,7 +74,7 @@ module LogBench
             filter_x = detail_win.maxx - filter_text.length - 3
             if filter_x > 20  # Only show if there's enough space
               detail_win.setpos(0, filter_x)
-              detail_win.attron(color_pair(4)) { detail_win.addstr(filter_text) }
+              detail_win.attron(color_pair(WARNING_YELLOW)) { detail_win.addstr(filter_text) }
             end
           end
         end
@@ -95,7 +102,7 @@ module LogBench
             # Draw highlight background if selected
             if is_selected
               detail_win.setpos(y, 1)
-              detail_win.attron(color_pair(10) | A_DIM) do
+              detail_win.attron(color_pair(SELECTION_HIGHLIGHT) | A_DIM) do
                 detail_win.addstr(" " * (detail_win.maxx - 2))
               end
             end
@@ -106,7 +113,7 @@ module LogBench
             if line_data.is_a?(Hash) && line_data[:segments]
               line_data[:segments].each do |segment|
                 if is_selected
-                  detail_win.attron(color_pair(10) | A_DIM) { detail_win.addstr(segment[:text]) }
+                  detail_win.attron(color_pair(SELECTION_HIGHLIGHT) | A_DIM) { detail_win.addstr(segment[:text]) }
                 elsif segment[:color]
                   detail_win.attron(segment[:color]) { detail_win.addstr(segment[:text]) }
                 else
@@ -118,14 +125,14 @@ module LogBench
               if is_selected
                 # For selected ANSI lines, render without ANSI codes to maintain highlight
                 plain_text = line_data[:text].gsub(/\e\[[0-9;]*m/, "")
-                detail_win.attron(color_pair(10) | A_DIM) { detail_win.addstr(plain_text) }
+                detail_win.attron(color_pair(SELECTION_HIGHLIGHT) | A_DIM) { detail_win.addstr(plain_text) }
               else
                 ansi_renderer.parse_and_render(line_data[:text], detail_win)
               end
             elsif line_data.is_a?(Hash)
               # Handle single-color lines
               if is_selected
-                detail_win.attron(color_pair(10) | A_DIM) { detail_win.addstr(line_data[:text]) }
+                detail_win.attron(color_pair(SELECTION_HIGHLIGHT) | A_DIM) { detail_win.addstr(line_data[:text]) }
               elsif line_data[:color]
                 detail_win.attron(line_data[:color]) { detail_win.addstr(line_data[:text]) }
               else
@@ -133,7 +140,7 @@ module LogBench
               end
             elsif is_selected
               # Simple string
-              detail_win.attron(color_pair(10) | A_DIM) { detail_win.addstr(line_data.to_s) }
+              detail_win.attron(color_pair(SELECTION_HIGHLIGHT) | A_DIM) { detail_win.addstr(line_data.to_s) }
             else
               detail_win.addstr(line_data.to_s)
             end
@@ -164,11 +171,11 @@ module LogBench
 
           # Method - separate label and value colors
           method_color = case request.method
-          when "GET" then color_pair(3) | A_BOLD
-          when "POST" then color_pair(4) | A_BOLD
-          when "PUT" then color_pair(5) | A_BOLD
-          when "DELETE" then color_pair(6) | A_BOLD
-          else color_pair(2) | A_BOLD
+          when "GET" then color_pair(SUCCESS_GREEN) | A_BOLD
+          when "POST" then color_pair(WARNING_YELLOW) | A_BOLD
+          when "PUT" then color_pair(INFO_BLUE) | A_BOLD
+          when "DELETE" then color_pair(ERROR_RED) | A_BOLD
+          else color_pair(DEFAULT_WHITE) | A_BOLD
           end
 
           lines << EMPTY_LINE.merge(entry_id: entry_id)
@@ -178,7 +185,7 @@ module LogBench
             color: nil,
             entry_id: entry_id,
             segments: [
-              {text: "Method: ", color: color_pair(1)},
+              {text: "Method: ", color: color_pair(HEADER_CYAN)},
               {text: request.method, color: method_color}
             ]
           }
@@ -214,7 +221,7 @@ module LogBench
               color: nil,
               entry_id: entry_id,
               segments: [
-                {text: path_prefix, color: color_pair(1)},
+                {text: path_prefix, color: color_pair(HEADER_CYAN)},
                 {text: remaining_path, color: nil}  # Default white color
               ]
             }
@@ -226,7 +233,7 @@ module LogBench
               color: nil,
               entry_id: entry_id,
               segments: [
-                {text: path_prefix, color: color_pair(1)},
+                {text: path_prefix, color: color_pair(HEADER_CYAN)},
                 {text: first_chunk, color: nil}  # Default white color
               ]
             }
@@ -245,20 +252,20 @@ module LogBench
           if request.status
             # Add status color coding
             status_color = case request.status
-            when 200..299 then color_pair(3)  # Green
-            when 300..399 then color_pair(4)  # Yellow
-            when 400..599 then color_pair(6)  # Red
-            else color_pair(2)                # Default
+            when 200..299 then color_pair(SUCCESS_GREEN)
+            when 300..399 then color_pair(WARNING_YELLOW)
+            when 400..599 then color_pair(ERROR_RED)
+            else color_pair(DEFAULT_WHITE)
             end
 
             # Build segments for mixed coloring
             segments = [
-              {text: "Status: ", color: color_pair(1)},
+              {text: "Status: ", color: color_pair(HEADER_CYAN)},
               {text: request.status.to_s, color: status_color}
             ]
 
             if request.duration
-              segments << {text: " | Duration: ", color: color_pair(1)}
+              segments << {text: " | Duration: ", color: color_pair(HEADER_CYAN)}
               segments << {text: "#{request.duration}ms", color: nil}  # Default white color
             end
 
@@ -280,7 +287,7 @@ module LogBench
               color: nil,
               entry_id: entry_id,
               segments: [
-                {text: "Controller: ", color: color_pair(1)},
+                {text: "Controller: ", color: color_pair(HEADER_CYAN)},
                 {text: controller_value, color: nil}  # Default white color
               ]
             }
@@ -296,7 +303,7 @@ module LogBench
             color: nil,
             entry_id: entry_id,
             segments: [
-              {text: "Params:", color: color_pair(1) | A_BOLD}
+              {text: "Params:", color: color_pair(HEADER_CYAN) | A_BOLD}
             ]
           }
 
@@ -369,7 +376,7 @@ module LogBench
               color: nil,
               entry_id: entry_id,
               segments: [
-                {text: "Request ID: ", color: color_pair(1)},
+                {text: "Request ID: ", color: color_pair(HEADER_CYAN)},
                 {text: request.request_id, color: nil}  # Default white color
               ]
             }
@@ -387,7 +394,7 @@ module LogBench
               color: nil,
               entry_id: entry_id,
               segments: [
-                {text: "Timestamp: ", color: color_pair(1)},
+                {text: "Timestamp: ", color: color_pair(HEADER_CYAN)},
                 {text: request.timestamp.strftime("%Y-%m-%d %H:%M:%S UTC"), color: nil}  # Default white color
               ]
             }
@@ -415,16 +422,16 @@ module LogBench
 
             # Show filter status in summary if filtering is active
             summary_title = "Query Summary:"
-            lines << {text: summary_title, color: color_pair(1) | A_BOLD, entry_id: entry_id}
+            lines << {text: summary_title, color: color_pair(HEADER_CYAN) | A_BOLD, entry_id: entry_id}
 
             if query_stats[:total_queries] > 0
               # Use QuerySummary methods for consistent formatting
               summary_line = query_summary.build_summary_line(query_stats)
-              lines << {text: "  #{summary_line}", color: color_pair(2), entry_id: entry_id}
+              lines << {text: "  #{summary_line}", color: color_pair(DEFAULT_WHITE), entry_id: entry_id}
 
               breakdown_line = query_summary.build_breakdown_line(query_stats)
               unless breakdown_line.empty?
-                lines << {text: "  #{breakdown_line}", color: color_pair(2), entry_id: entry_id}
+                lines << {text: "  #{breakdown_line}", color: color_pair(DEFAULT_WHITE), entry_id: entry_id}
               end
             end
 
@@ -440,13 +447,13 @@ module LogBench
                 color: nil,
                 entry_id: entry_id,
                 segments: [
-                  {text: "Related Logs ", color: color_pair(1) | A_BOLD},
+                  {text: "Related Logs ", color: color_pair(HEADER_CYAN) | A_BOLD},
                   {text: count_text, color: A_DIM},
-                  {text: ":", color: color_pair(1) | A_BOLD}
+                  {text: ":", color: color_pair(HEADER_CYAN) | A_BOLD}
                 ]
               }
             else
-              lines << {text: "Related Logs:", color: color_pair(1) | A_BOLD, entry_id: entry_id}
+              lines << {text: "Related Logs:", color: color_pair(HEADER_CYAN) | A_BOLD, entry_id: entry_id}
             end
 
             # Use filtered logs for display - group SQL queries with their call source lines

--- a/lib/log_bench/app/renderer/header.rb
+++ b/lib/log_bench/app/renderer/header.rb
@@ -15,8 +15,8 @@ module LogBench
         TITLE_X_OFFSET = 2
 
         # Color constants
-        HEADER_CYAN = 1
-        SUCCESS_GREEN = 3
+        HEADER_CYAN = Screen::HEADER_CYAN
+        SUCCESS_GREEN = Screen::SUCCESS_GREEN
 
         def initialize(screen, state, log_file_name)
           self.screen = screen
@@ -50,7 +50,7 @@ module LogBench
         end
 
         def draw_stats
-          if state.main_filter.present?
+          if state.request_filters_present?
             draw_filtered_stats
           else
             draw_stats_panel
@@ -63,9 +63,9 @@ module LogBench
           total_requests = state.requests.size
           stats_text = "#{filtered_requests.size} found (#{total_requests} total)"
           header_win.setpos(1, screen.width - stats_text.length - 2)
-          header_win.attron(color_pair(3)) { header_win.addstr(filtered_requests.size.to_s) }
+          header_win.attron(color_pair(SUCCESS_GREEN)) { header_win.addstr(filtered_requests.size.to_s) }
           header_win.addstr(" found (")
-          header_win.attron(color_pair(3)) { header_win.addstr(total_requests.to_s) }
+          header_win.attron(color_pair(SUCCESS_GREEN)) { header_win.addstr(total_requests.to_s) }
           header_win.addstr(" total)")
         end
 
@@ -120,18 +120,18 @@ module LogBench
           header_win.attron(A_DIM) do
             help_line_1 = "a:Auto-scroll("
             header_win.addstr(help_line_1)
-            header_win.attron(color_pair(3)) { header_win.addstr(state.auto_scroll ? "ON" : "OFF") }
-            header_win.addstr(") | f:Filter | c:Clear filter | s:Sort(")
-            header_win.attron(color_pair(3)) { header_win.addstr(state.sort.display_name) }
+            header_win.attron(color_pair(SUCCESS_GREEN)) { header_win.addstr(state.auto_scroll ? "ON" : "OFF") }
+            header_win.addstr(") | f:Filter cols | c:Clear filter | s:Sort(")
+            header_win.attron(color_pair(SUCCESS_GREEN)) { header_win.addstr(state.sort.display_name) }
             header_win.addstr(") | t:Text selection(")
-            header_win.attron(color_pair(3)) { header_win.addstr(state.text_selection_mode? ? "ON" : "OFF") }
+            header_win.attron(color_pair(SUCCESS_GREEN)) { header_win.addstr(state.text_selection_mode? ? "ON" : "OFF") }
             header_win.addstr(") | q:Quit")
           end
 
           header_win.setpos(3, 2)
           header_win.attron(A_DIM) do
             header_win.addstr("←→/hl:Pane | ↑↓/jk:Navigate | g/G:Top/End | y:Copy highlighted | Ctrl+L:Clear | Ctrl+R:Restore(")
-            header_win.attron(color_pair(3)) { header_win.addstr(state.can_undo_clear? ? "READY" : "N/A") }
+            header_win.attron(color_pair(SUCCESS_GREEN)) { header_win.addstr(state.can_undo_clear? ? "READY" : "N/A") }
             header_win.addstr(")")
           end
         end

--- a/lib/log_bench/app/renderer/request_filter_bar.rb
+++ b/lib/log_bench/app/renderer/request_filter_bar.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+module LogBench
+  module App
+    module Renderer
+      class RequestFilterBar
+        include Curses
+
+        FILTER_HINT_TEXT = "Press f to start filtering, operators allowed: > >= < <= 50-100"
+        FILTER_RIGHT_EDGE_OFFSET = 2
+        FILTER_STATUS_WIDTH = 7
+        FILTER_TIME_WIDTH = 8
+        CURSOR_BLINK_INTERVAL_SECONDS = 0.5
+
+        DEFAULT_WHITE = Screen::DEFAULT_WHITE
+        FILTER_CELL_BACKGROUND = Screen::FILTER_CELL_BACKGROUND
+
+        def initialize(screen, state, header_x_offset:, row_y:, method_width:)
+          self.screen = screen
+          self.state = state
+          self.header_x_offset = header_x_offset
+          self.row_y = row_y
+          self.method_width = method_width
+        end
+
+        def draw
+          if show_filter_cells?
+            draw_filter_cells_row
+          else
+            draw_filter_hint_row
+          end
+        end
+
+        def self.layout(panel_width, header_x_offset:, method_width:)
+          filter_right_edge = panel_width - FILTER_RIGHT_EDGE_OFFSET
+          time_start = filter_right_edge - FILTER_TIME_WIDTH
+          status_start = time_start - FILTER_STATUS_WIDTH
+          path_start = header_x_offset + method_width
+          path_width = [status_start - path_start, 1].max
+
+          {
+            method: (header_x_offset...(header_x_offset + method_width)),
+            path: (path_start...(path_start + path_width)),
+            status: (status_start...(status_start + FILTER_STATUS_WIDTH)),
+            time: (time_start...(time_start + FILTER_TIME_WIDTH)),
+            path_width: path_width,
+            status_start: status_start,
+            time_start: time_start,
+            filter_right_edge: filter_right_edge
+          }
+        end
+
+        private
+
+        attr_accessor :screen, :state, :header_x_offset, :row_y, :method_width
+
+        def show_filter_cells?
+          state.filter_mode || state.request_filters_present?
+        end
+
+        def draw_filter_hint_row
+          log_win.setpos(row_y, header_x_offset)
+          consumed = draw_filter_hint_prefix(filter_row_width)
+          fill_remaining_filter_row(consumed)
+        end
+
+        def draw_filter_hint_prefix(width)
+          return 0 if width <= 0
+
+          hint_text = FILTER_HINT_TEXT[0, width].ljust(width)
+          log_win.attron(color_pair(DEFAULT_WHITE) | A_DIM) { log_win.addstr(hint_text) }
+          hint_text.length
+        end
+
+        def fill_remaining_filter_row(consumed_width)
+          remaining = filter_row_width - consumed_width
+          return if remaining <= 0
+
+          log_win.attron(color_pair(DEFAULT_WHITE) | A_DIM) { log_win.addstr(" " * remaining) }
+        end
+
+        def draw_filter_cells_row
+          current_layout = layout
+
+          log_win.setpos(row_y, header_x_offset)
+          draw_filter_cell(:method, method_width)
+          draw_filter_cell(:path, current_layout[:path_width])
+
+          log_win.setpos(row_y, current_layout[:status_start])
+          draw_filter_cell(:status, FILTER_STATUS_WIDTH)
+
+          log_win.setpos(row_y, current_layout[:time_start])
+          draw_filter_cell(:time, FILTER_TIME_WIDTH)
+        end
+
+        def draw_filter_cell(column, width)
+          filter_text = filter_text_for(column, width)
+          log_win.attron(filter_cell_attributes(column)) { log_win.addstr(filter_text) }
+        end
+
+        def filter_text_for(column, width)
+          filter = state.request_filter_for(column)
+          text = filter.display_text.to_s
+          text = "#{text}#{active_filter_cursor}" if active_filter_column?(column)
+
+          align_filter_text(column, text, width)
+        end
+
+        def align_filter_text(column, text, width)
+          if column == :status
+            visible_text = text[0, width]
+            visible_text.rjust(width - 1).ljust(width)
+          elsif column == :time
+            visible_text = text[0, width - 1]
+            " #{visible_text}".ljust(width)
+          else
+            text[0, width].ljust(width)
+          end
+        end
+
+        def active_filter_column?(column)
+          state.filter_mode && state.active_request_filter_column == column
+        end
+
+        def filter_cell_attributes(column)
+          base = color_pair(FILTER_CELL_BACKGROUND) | A_DIM
+          active_filter_column?(column) ? color_pair(FILTER_CELL_BACKGROUND) : base
+        end
+
+        def active_filter_cursor
+          cursor_visible? ? "█" : " "
+        end
+
+        def cursor_visible?
+          blink_tick = (Process.clock_gettime(Process::CLOCK_MONOTONIC) / CURSOR_BLINK_INTERVAL_SECONDS).to_i
+          blink_tick.even?
+        end
+
+        def layout
+          self.class.layout(
+            screen.panel_width,
+            header_x_offset: header_x_offset,
+            method_width: method_width
+          )
+        end
+
+        def filter_row_width
+          layout[:filter_right_edge] - header_x_offset
+        end
+
+        def color_pair(n)
+          screen.color_pair(n)
+        end
+
+        def log_win
+          screen.log_win
+        end
+      end
+    end
+  end
+end

--- a/lib/log_bench/app/renderer/request_list.rb
+++ b/lib/log_bench/app/renderer/request_list.rb
@@ -11,18 +11,13 @@ module LogBench
         COLUMN_HEADER_Y = 1
         FILTER_ROW_Y = 2
         ROWS_START_Y = 3
-        FILTER_HINT_TEXT = "Press f to start filtering, operators allowed: > >= < <= 50-100"
-        FILTER_RIGHT_EDGE_OFFSET = 2
 
         # Column widths
         METHOD_WIDTH = 8
         STATUS_WIDTH = 8
         TIME_WIDTH = 6
         STATUS_RENDER_WIDTH = 4
-        FILTER_STATUS_WIDTH = 7
-        FILTER_TIME_WIDTH = 8
         PATH_MARGIN = 27
-        CURSOR_BLINK_INTERVAL_SECONDS = 0.5
 
         # Color constants
         HEADER_CYAN = Screen::HEADER_CYAN
@@ -32,12 +27,18 @@ module LogBench
         INFO_BLUE = Screen::INFO_BLUE
         ERROR_RED = Screen::ERROR_RED
         SELECTION_HIGHLIGHT = Screen::SELECTION_HIGHLIGHT
-        FILTER_CELL_BACKGROUND = Screen::FILTER_CELL_BACKGROUND
 
         def initialize(screen, state, scrollbar)
           self.screen = screen
           self.state = state
           self.scrollbar = scrollbar
+          self.filter_bar = RequestFilterBar.new(
+            screen,
+            state,
+            header_x_offset: HEADER_Y_OFFSET,
+            row_y: FILTER_ROW_Y,
+            method_width: METHOD_WIDTH
+          )
         end
 
         def draw
@@ -52,7 +53,7 @@ module LogBench
 
         private
 
-        attr_accessor :screen, :state, :scrollbar
+        attr_accessor :screen, :state, :scrollbar, :filter_bar
 
         def draw_header
           log_win.setpos(0, HEADER_Y_OFFSET)
@@ -80,89 +81,7 @@ module LogBench
         end
 
         def draw_filter_row
-          if show_filter_cells?
-            draw_filter_cells_row
-          else
-            draw_filter_hint_row
-          end
-        end
-
-        def show_filter_cells?
-          state.filter_mode || state.request_filters_present?
-        end
-
-        def draw_filter_hint_row
-          log_win.setpos(FILTER_ROW_Y, HEADER_Y_OFFSET)
-          consumed = draw_filter_hint_prefix(filter_row_width)
-          fill_remaining_filter_row(consumed)
-        end
-
-        def draw_filter_hint_prefix(width)
-          return 0 if width <= 0
-
-          hint_text = FILTER_HINT_TEXT[0, width].ljust(width)
-          log_win.attron(color_pair(DEFAULT_WHITE) | A_DIM) { log_win.addstr(hint_text) }
-          hint_text.length
-        end
-
-        def fill_remaining_filter_row(consumed_width)
-          remaining = filter_row_width - consumed_width
-          return if remaining <= 0
-
-          log_win.attron(color_pair(DEFAULT_WHITE) | A_DIM) { log_win.addstr(" " * remaining) }
-        end
-
-        def draw_filter_cells_row
-          log_win.setpos(FILTER_ROW_Y, HEADER_Y_OFFSET)
-          draw_filter_cell(:method, METHOD_WIDTH)
-          draw_filter_cell(:path, filter_path_column_width)
-          log_win.setpos(FILTER_ROW_Y, status_filter_col_start)
-          draw_filter_cell(:status, status_filter_width)
-          log_win.setpos(FILTER_ROW_Y, time_filter_col_start)
-          draw_filter_cell(:time, time_filter_width)
-        end
-
-        def draw_filter_cell(column, width)
-          filter_text = filter_text_for(column, width)
-          log_win.attron(filter_cell_attributes(column)) { log_win.addstr(filter_text) }
-        end
-
-        def filter_text_for(column, width)
-          filter = state.request_filter_for(column)
-          text = filter.display_text.to_s
-          text = "#{text}#{active_filter_cursor}" if active_filter_column?(column)
-
-          align_filter_text(column, text, width)
-        end
-
-        def align_filter_text(column, text, width)
-          if column == :status
-            visible_text = text[0, width]
-            visible_text.rjust(width - 1).ljust(width)
-          elsif column == :time
-            visible_text = text[0, width - 1]
-            " #{visible_text}".ljust(width)
-          else
-            text[0, width].ljust(width)
-          end
-        end
-
-        def active_filter_column?(column)
-          state.filter_mode && state.active_request_filter_column == column
-        end
-
-        def filter_cell_attributes(column)
-          base = color_pair(FILTER_CELL_BACKGROUND) | A_DIM
-          active_filter_column?(column) ? color_pair(FILTER_CELL_BACKGROUND) : base
-        end
-
-        def active_filter_cursor
-          cursor_visible? ? "█" : " "
-        end
-
-        def cursor_visible?
-          blink_tick = (Process.clock_gettime(Process::CLOCK_MONOTONIC) / CURSOR_BLINK_INTERVAL_SECONDS).to_i
-          blink_tick.even?
+          filter_bar.draw
         end
 
         def draw_rows
@@ -280,34 +199,6 @@ module LogBench
 
         def path_column_width
           screen.panel_width - PATH_MARGIN
-        end
-
-        def filter_path_column_width
-          [status_filter_col_start - (HEADER_Y_OFFSET + METHOD_WIDTH), 1].max
-        end
-
-        def status_filter_width
-          FILTER_STATUS_WIDTH
-        end
-
-        def time_filter_width
-          FILTER_TIME_WIDTH
-        end
-
-        def filter_row_width
-          filter_right_edge - HEADER_Y_OFFSET
-        end
-
-        def status_filter_col_start
-          time_filter_col_start - status_filter_width
-        end
-
-        def time_filter_col_start
-          filter_right_edge - time_filter_width
-        end
-
-        def filter_right_edge
-          screen.panel_width - FILTER_RIGHT_EDGE_OFFSET
         end
 
         def status_col_start

--- a/lib/log_bench/app/renderer/request_list.rb
+++ b/lib/log_bench/app/renderer/request_list.rb
@@ -67,11 +67,16 @@ module LogBench
         def draw_column_headers
           log_win.setpos(COLUMN_HEADER_Y, HEADER_Y_OFFSET)
           log_win.attron(color_pair(HEADER_CYAN) | A_DIM) do
-            log_win.addstr("METHOD".ljust(METHOD_WIDTH))
+            log_win.addstr(column_header_text("METHOD", :method).ljust(METHOD_WIDTH))
             log_win.addstr("PATH".ljust(path_column_width))
-            log_win.addstr("STATUS".ljust(STATUS_WIDTH))
-            log_win.addstr("TIME")
+            log_win.addstr(column_header_text("STATUS", :status).ljust(STATUS_WIDTH))
+            log_win.addstr(column_header_text("TIME", :time))
           end
+        end
+
+        def column_header_text(label, column)
+          sort_arrow = state.sort_arrow_for_column(column)
+          sort_arrow ? "#{label}#{sort_arrow}" : label
         end
 
         def draw_filter_row

--- a/lib/log_bench/app/renderer/request_list.rb
+++ b/lib/log_bench/app/renderer/request_list.rb
@@ -9,19 +9,30 @@ module LogBench
         # Layout constants
         HEADER_Y_OFFSET = 2
         COLUMN_HEADER_Y = 1
-        MIN_FILTER_X_POSITION = 20
-        FILTER_X_MARGIN = 3
+        FILTER_ROW_Y = 2
+        ROWS_START_Y = 3
+        FILTER_HINT_TEXT = "Press f to start filtering, operators allowed: > >= < <= 50-100"
+        FILTER_RIGHT_EDGE_OFFSET = 2
 
         # Column widths
         METHOD_WIDTH = 8
         STATUS_WIDTH = 8
+        TIME_WIDTH = 6
+        STATUS_RENDER_WIDTH = 4
+        FILTER_STATUS_WIDTH = 7
+        FILTER_TIME_WIDTH = 8
         PATH_MARGIN = 27
+        CURSOR_BLINK_INTERVAL_SECONDS = 0.5
 
         # Color constants
-        HEADER_CYAN = 1
-        DEFAULT_WHITE = 2
-        WARNING_YELLOW = 4
-        SELECTION_HIGHLIGHT = 10
+        HEADER_CYAN = Screen::HEADER_CYAN
+        DEFAULT_WHITE = Screen::DEFAULT_WHITE
+        SUCCESS_GREEN = Screen::SUCCESS_GREEN
+        WARNING_YELLOW = Screen::WARNING_YELLOW
+        INFO_BLUE = Screen::INFO_BLUE
+        ERROR_RED = Screen::ERROR_RED
+        SELECTION_HIGHLIGHT = Screen::SELECTION_HIGHLIGHT
+        FILTER_CELL_BACKGROUND = Screen::FILTER_CELL_BACKGROUND
 
         def initialize(screen, state, scrollbar)
           self.screen = screen
@@ -35,6 +46,7 @@ module LogBench
 
           draw_header
           draw_column_headers
+          draw_filter_row
           draw_rows
         end
 
@@ -50,37 +62,107 @@ module LogBench
           else
             log_win.attron(color_pair(DEFAULT_WHITE) | A_DIM) { log_win.addstr(" Request Logs ") }
           end
-
-          show_filter_in_header if show_filter?
-        end
-
-        def show_filter?
-          state.main_filter.present? || state.main_filter.active?
-        end
-
-        def show_filter_in_header
-          filter_text = "Filter: #{state.main_filter.cursor_display}"
-          filter_x = log_win.maxx - filter_text.length - FILTER_X_MARGIN
-
-          if filter_x > MIN_FILTER_X_POSITION
-            log_win.setpos(0, filter_x)
-            log_win.attron(color_pair(WARNING_YELLOW)) { log_win.addstr(filter_text) }
-          end
         end
 
         def draw_column_headers
           log_win.setpos(COLUMN_HEADER_Y, HEADER_Y_OFFSET)
           log_win.attron(color_pair(HEADER_CYAN) | A_DIM) do
             log_win.addstr("METHOD".ljust(METHOD_WIDTH))
-            log_win.addstr("PATH".ljust(screen.panel_width - PATH_MARGIN))
+            log_win.addstr("PATH".ljust(path_column_width))
             log_win.addstr("STATUS".ljust(STATUS_WIDTH))
             log_win.addstr("TIME")
           end
         end
 
+        def draw_filter_row
+          if show_filter_cells?
+            draw_filter_cells_row
+          else
+            draw_filter_hint_row
+          end
+        end
+
+        def show_filter_cells?
+          state.filter_mode || state.request_filters_present?
+        end
+
+        def draw_filter_hint_row
+          log_win.setpos(FILTER_ROW_Y, HEADER_Y_OFFSET)
+          consumed = draw_filter_hint_prefix(filter_row_width)
+          fill_remaining_filter_row(consumed)
+        end
+
+        def draw_filter_hint_prefix(width)
+          return 0 if width <= 0
+
+          hint_text = FILTER_HINT_TEXT[0, width].ljust(width)
+          log_win.attron(color_pair(DEFAULT_WHITE) | A_DIM) { log_win.addstr(hint_text) }
+          hint_text.length
+        end
+
+        def fill_remaining_filter_row(consumed_width)
+          remaining = filter_row_width - consumed_width
+          return if remaining <= 0
+
+          log_win.attron(color_pair(DEFAULT_WHITE) | A_DIM) { log_win.addstr(" " * remaining) }
+        end
+
+        def draw_filter_cells_row
+          log_win.setpos(FILTER_ROW_Y, HEADER_Y_OFFSET)
+          draw_filter_cell(:method, METHOD_WIDTH)
+          draw_filter_cell(:path, filter_path_column_width)
+          log_win.setpos(FILTER_ROW_Y, status_filter_col_start)
+          draw_filter_cell(:status, status_filter_width)
+          log_win.setpos(FILTER_ROW_Y, time_filter_col_start)
+          draw_filter_cell(:time, time_filter_width)
+        end
+
+        def draw_filter_cell(column, width)
+          filter_text = filter_text_for(column, width)
+          log_win.attron(filter_cell_attributes(column)) { log_win.addstr(filter_text) }
+        end
+
+        def filter_text_for(column, width)
+          filter = state.request_filter_for(column)
+          text = filter.display_text.to_s
+          text = "#{text}#{active_filter_cursor}" if active_filter_column?(column)
+
+          align_filter_text(column, text, width)
+        end
+
+        def align_filter_text(column, text, width)
+          if column == :status
+            visible_text = text[0, width]
+            visible_text.rjust(width - 1).ljust(width)
+          elsif column == :time
+            visible_text = text[0, width - 1]
+            " #{visible_text}".ljust(width)
+          else
+            text[0, width].ljust(width)
+          end
+        end
+
+        def active_filter_column?(column)
+          state.filter_mode && state.active_request_filter_column == column
+        end
+
+        def filter_cell_attributes(column)
+          base = color_pair(FILTER_CELL_BACKGROUND) | A_DIM
+          active_filter_column?(column) ? color_pair(FILTER_CELL_BACKGROUND) : base
+        end
+
+        def active_filter_cursor
+          cursor_visible? ? "█" : " "
+        end
+
+        def cursor_visible?
+          blink_tick = (Process.clock_gettime(Process::CLOCK_MONOTONIC) / CURSOR_BLINK_INTERVAL_SECONDS).to_i
+          blink_tick.even?
+        end
+
         def draw_rows
           filtered_requests = state.filtered_requests
-          visible_height = log_win.maxy - 3
+          visible_height = log_win.maxy - 4
 
           return draw_no_requests_message if filtered_requests.empty?
 
@@ -91,7 +173,7 @@ module LogBench
             request_index = state.scroll_offset + i
             break if request_index >= filtered_requests.size
 
-            draw_row(filtered_requests[request_index], request_index, i + 2)
+            draw_row(filtered_requests[request_index], request_index, i + ROWS_START_Y)
           end
 
           # Draw scrollbar if needed
@@ -110,7 +192,7 @@ module LogBench
           is_selected = request_index == state.selected
 
           if is_selected
-            log_win.attron(color_pair(10) | A_DIM) do
+            log_win.attron(color_pair(SELECTION_HIGHLIGHT) | A_DIM) do
               log_win.addstr(" " * (screen.panel_width - 4))
             end
             log_win.setpos(y_position, 1)
@@ -126,7 +208,7 @@ module LogBench
           method_text = " #{request.method.ljust(7)} "
 
           if is_selected
-            log_win.attron(color_pair(10) | A_DIM) { log_win.addstr(method_text) }
+            log_win.attron(color_pair(SELECTION_HIGHLIGHT) | A_DIM) { log_win.addstr(method_text) }
           else
             method_color = method_color_for(request.method)
             log_win.attron(color_pair(method_color) | A_BOLD) { log_win.addstr(method_text) }
@@ -134,12 +216,12 @@ module LogBench
         end
 
         def draw_path_column(request, is_selected)
-          path_width = screen.panel_width - 27
-          path = request.path[0, path_width] || ""
+          path = request.path[0, path_column_width] || ""
+          path_width = path_column_width
           path_text = path.ljust(path_width)
 
           if is_selected
-            log_win.attron(color_pair(10) | A_DIM) { log_win.addstr(path_text) }
+            log_win.attron(color_pair(SELECTION_HIGHLIGHT) | A_DIM) { log_win.addstr(path_text) }
           else
             log_win.addstr(path_text)
           end
@@ -148,12 +230,11 @@ module LogBench
         def draw_status_column(request, is_selected)
           return unless request.status
 
-          status_col_start = screen.panel_width - 14
           status_text = "#{request.status.to_s.rjust(3)} "
 
           log_win.setpos(log_win.cury, status_col_start)
           if is_selected
-            log_win.attron(color_pair(10) | A_DIM) { log_win.addstr(status_text) }
+            log_win.attron(color_pair(SELECTION_HIGHLIGHT) | A_DIM) { log_win.addstr(status_text) }
           else
             status_color = status_color_for(request.status)
             log_win.attron(color_pair(status_color)) { log_win.addstr(status_text) }
@@ -163,12 +244,11 @@ module LogBench
         def draw_duration_column(request, is_selected)
           return unless request.duration
 
-          duration_col_start = screen.panel_width - 9
           duration_text = "#{request.duration.to_i}ms".ljust(6) + " "
 
           log_win.setpos(log_win.cury, duration_col_start)
           if is_selected
-            log_win.attron(color_pair(10) | A_DIM) { log_win.addstr(duration_text) }
+            log_win.attron(color_pair(SELECTION_HIGHLIGHT) | A_DIM) { log_win.addstr(duration_text) }
           else
             log_win.attron(A_DIM) { log_win.addstr(duration_text) }
           end
@@ -176,21 +256,61 @@ module LogBench
 
         def method_color_for(method)
           case method
-          when "GET" then 3
-          when "POST" then 4
-          when "PUT" then 5
-          when "DELETE" then 6
-          else 2
+          when "GET" then SUCCESS_GREEN
+          when "POST" then WARNING_YELLOW
+          when "PUT" then INFO_BLUE
+          when "DELETE" then ERROR_RED
+          else DEFAULT_WHITE
           end
         end
 
         def status_color_for(status)
           case status
-          when 200..299 then 3
-          when 300..399 then 4
-          when 400..599 then 6
-          else 2
+          when 200..299 then SUCCESS_GREEN
+          when 300..399 then WARNING_YELLOW
+          when 400..599 then ERROR_RED
+          else DEFAULT_WHITE
           end
+        end
+
+        def path_column_width
+          screen.panel_width - PATH_MARGIN
+        end
+
+        def filter_path_column_width
+          [status_filter_col_start - (HEADER_Y_OFFSET + METHOD_WIDTH), 1].max
+        end
+
+        def status_filter_width
+          FILTER_STATUS_WIDTH
+        end
+
+        def time_filter_width
+          FILTER_TIME_WIDTH
+        end
+
+        def filter_row_width
+          filter_right_edge - HEADER_Y_OFFSET
+        end
+
+        def status_filter_col_start
+          time_filter_col_start - status_filter_width
+        end
+
+        def time_filter_col_start
+          filter_right_edge - time_filter_width
+        end
+
+        def filter_right_edge
+          screen.panel_width - FILTER_RIGHT_EDGE_OFFSET
+        end
+
+        def status_col_start
+          screen.panel_width - 14
+        end
+
+        def duration_col_start
+          screen.panel_width - 9
         end
 
         def color_pair(n)

--- a/lib/log_bench/app/renderer/scrollbar.rb
+++ b/lib/log_bench/app/renderer/scrollbar.rb
@@ -5,6 +5,7 @@ module LogBench
     module Renderer
       class Scrollbar
         include Curses
+        SCROLLBAR_THUMB_COLOR = Screen::HEADER_CYAN
 
         def initialize(screen)
           self.screen = screen
@@ -20,7 +21,7 @@ module LogBench
           height.times do |i|
             win.setpos(i + 1, x)
             if i >= scrollbar_pos && i < scrollbar_pos + scrollbar_height
-              win.attron(color_pair(1)) { win.addstr("█") }  # Solid block for scrollbar thumb
+              win.attron(color_pair(SCROLLBAR_THUMB_COLOR)) { win.addstr("█") }  # Solid block for scrollbar thumb
             end
           end
         end

--- a/lib/log_bench/app/screen.rb
+++ b/lib/log_bench/app/screen.rb
@@ -9,8 +9,11 @@ module LogBench
       HEADER_HEIGHT = 5
       PANEL_BORDER_WIDTH = 3
       INPUT_TIMEOUT_MS = 200
+      TRANSPARENT_BACKGROUND = -1
+      EXTENDED_COLOR_THRESHOLD = 253
+      NO_COLOR_SUPPORT = 0
 
-      # Color pairs
+      # Color pairs (identifiers)
       HEADER_CYAN = 1
       DEFAULT_WHITE = 2
       SUCCESS_GREEN = 3    # GET requests, 200 status
@@ -21,6 +24,7 @@ module LogBench
       BLACK = 8
       MAGENTA = 9
       SELECTION_HIGHLIGHT = 10
+      FILTER_CELL_BACKGROUND = 11
 
       attr_reader :header_win, :log_win, :panel_width, :detail_win
 
@@ -89,17 +93,35 @@ module LogBench
         stdscr.keypad(true)
         stdscr.timeout = INPUT_TIMEOUT_MS
 
-        # Define color pairs with transparent background (-1)
-        init_pair(HEADER_CYAN, COLOR_CYAN, -1)      # Header/Cyan
-        init_pair(DEFAULT_WHITE, COLOR_WHITE, -1)     # Default/White
-        init_pair(SUCCESS_GREEN, COLOR_GREEN, -1)     # GET/Success/Green
-        init_pair(WARNING_YELLOW, COLOR_YELLOW, -1)    # POST/Warning/Yellow
-        init_pair(INFO_BLUE, COLOR_BLUE, -1)      # PUT/Blue
-        init_pair(ERROR_RED, COLOR_RED, -1)       # DELETE/Error/Red
-        init_pair(BRIGHT_WHITE, COLOR_WHITE, -1)     # Bold/Bright white
-        init_pair(BLACK, COLOR_BLACK, -1)     # Black
-        init_pair(MAGENTA, COLOR_MAGENTA, -1)   # Magenta
+        # Define color pairs with transparent background.
+        init_pair(HEADER_CYAN, COLOR_CYAN, TRANSPARENT_BACKGROUND)      # Header/Cyan
+        init_pair(DEFAULT_WHITE, COLOR_WHITE, TRANSPARENT_BACKGROUND)     # Default/White
+        init_pair(SUCCESS_GREEN, COLOR_GREEN, TRANSPARENT_BACKGROUND)     # GET/Success/Green
+        init_pair(WARNING_YELLOW, COLOR_YELLOW, TRANSPARENT_BACKGROUND)    # POST/Warning/Yellow
+        init_pair(INFO_BLUE, COLOR_BLUE, TRANSPARENT_BACKGROUND)      # PUT/Blue
+        init_pair(ERROR_RED, COLOR_RED, TRANSPARENT_BACKGROUND)       # DELETE/Error/Red
+        init_pair(BRIGHT_WHITE, COLOR_WHITE, TRANSPARENT_BACKGROUND)     # Bold/Bright white
+        init_pair(BLACK, COLOR_BLACK, TRANSPARENT_BACKGROUND)     # Black
+        init_pair(MAGENTA, COLOR_MAGENTA, TRANSPARENT_BACKGROUND)   # Magenta
         init_pair(SELECTION_HIGHLIGHT, COLOR_BLACK, COLOR_CYAN)     # Selection highlighting
+        if terminal_colors_count >= EXTENDED_COLOR_THRESHOLD
+          # Keep filter cell text readable on rich-color terminals.
+          init_pair(FILTER_CELL_BACKGROUND, COLOR_YELLOW, TRANSPARENT_BACKGROUND)
+        else
+          init_pair(FILTER_CELL_BACKGROUND, COLOR_BLACK, COLOR_WHITE)
+        end
+      end
+
+      def terminal_colors_count
+        if Curses.respond_to?(:colors)
+          Curses.colors.to_i
+        elsif defined?(COLORS)
+          COLORS.to_i
+        else
+          NO_COLOR_SUPPORT
+        end
+      rescue
+        NO_COLOR_SUPPORT
       end
 
       def cleanup_windows

--- a/lib/log_bench/app/sort.rb
+++ b/lib/log_bench/app/sort.rb
@@ -33,7 +33,11 @@ module LogBench
         return false unless target_mode
 
         if mode == target_mode
-          toggle_direction
+          if direction == DEFAULT_DIRECTIONS.fetch(mode)
+            toggle_direction
+          else
+            reset_to_default_sort
+          end
         else
           self.mode = target_mode
           self.direction = DEFAULT_DIRECTIONS.fetch(mode)
@@ -99,6 +103,11 @@ module LogBench
 
       def toggle_direction
         self.direction = (direction == :asc) ? :desc : :asc
+      end
+
+      def reset_to_default_sort
+        self.mode = :timestamp
+        self.direction = DEFAULT_DIRECTIONS.fetch(mode)
       end
     end
   end

--- a/lib/log_bench/app/sort.rb
+++ b/lib/log_bench/app/sort.rb
@@ -2,39 +2,79 @@ module LogBench
   module App
     class Sort
       MODES = [:timestamp, :duration, :method, :status].freeze
+      REQUEST_COLUMN_TO_MODE = {
+        method: :method,
+        status: :status,
+        time: :duration
+      }.freeze
+      DEFAULT_DIRECTIONS = {
+        timestamp: :asc,
+        duration: :desc,
+        method: :asc,
+        status: :desc
+      }.freeze
+      ASC_ARROW = "↑"
+      DESC_ARROW = "↓"
 
       def initialize
         self.mode = :timestamp
+        self.direction = DEFAULT_DIRECTIONS.fetch(mode)
       end
 
       def cycle
         current_index = MODES.index(mode)
         next_index = (current_index + 1) % MODES.length
         self.mode = MODES[next_index]
+        self.direction = DEFAULT_DIRECTIONS.fetch(mode)
+      end
+
+      def toggle_column(column)
+        target_mode = REQUEST_COLUMN_TO_MODE[column]
+        return false unless target_mode
+
+        if mode == target_mode
+          toggle_direction
+        else
+          self.mode = target_mode
+          self.direction = DEFAULT_DIRECTIONS.fetch(mode)
+        end
+
+        true
+      end
+
+      def sort_arrow_for_column(column)
+        target_mode = REQUEST_COLUMN_TO_MODE[column]
+        return nil unless target_mode == mode
+
+        (direction == :asc) ? ASC_ARROW : DESC_ARROW
       end
 
       def display_name
-        case mode
+        mode_name = case mode
         when :timestamp then "TIMESTAMP"
         when :duration then "DURATION"
         when :method then "METHOD"
         when :status then "STATUS"
         end
+
+        "#{mode_name} #{direction.to_s.upcase}"
       end
 
       def sort_requests(requests)
-        case mode
+        sorted = case mode
         when :timestamp
           requests.sort_by { |req| req.timestamp || Time.at(0) }
         when :duration
-          requests.sort_by { |req| -(req.duration || 0) }  # Descending (slowest first)
+          requests.sort_by { |req| req.duration || 0 }
         when :method
           requests.sort_by { |req| req.method || "" }
         when :status
-          requests.sort_by { |req| -(req.status || 0) }  # Descending (errors first)
+          requests.sort_by { |req| req.status || 0 }
         else
           requests
         end
+
+        (direction == :desc) ? sorted.reverse : sorted
       end
 
       def timestamp?
@@ -55,7 +95,11 @@ module LogBench
 
       private
 
-      attr_accessor :mode
+      attr_accessor :mode, :direction
+
+      def toggle_direction
+        self.direction = (direction == :asc) ? :desc : :asc
+      end
     end
   end
 end

--- a/lib/log_bench/app/state.rb
+++ b/lib/log_bench/app/state.rb
@@ -7,7 +7,14 @@ module LogBench
     class State
       include Singleton
 
-      attr_reader :main_filter, :sort, :detail_filter, :cleared_requests, :start_time, :stats, :total_queries
+      REQUEST_FILTER_COLUMNS = %i[method path status time].freeze
+      NUMERIC_COMPARATOR_REGEX = /\A(<=|>=|<|>)\s*(-?\d+(?:\.\d+)?)\z/
+      NUMERIC_COMPARATOR_ONLY_REGEX = /\A(<=|>=|<|>)\s*\z/
+      NUMERIC_RANGE_REGEX = /\A(-?\d+(?:\.\d+)?)\s*-\s*(-?\d+(?:\.\d+)?)\z/
+      NUMERIC_VALUE_REGEX = /\A-?\d+(?:\.\d+)?\z/
+      NUMERIC_COMPARISON_EPSILON = 0.0001
+
+      attr_reader :main_filter, :sort, :detail_filter, :cleared_requests, :start_time, :stats, :total_queries, :active_request_filter_column
       attr_accessor :requests, :orphan_requests, :auto_scroll, :scroll_offset, :selected, :detail_scroll_offset, :detail_selected_entry, :text_selection_mode, :update_available, :update_version
 
       def initialize
@@ -27,6 +34,8 @@ module LogBench
         self.text_selection_mode = false
         self.main_filter = Filter.new
         self.detail_filter = Filter.new
+        self.request_filters = build_request_filters
+        self.active_request_filter_column = :path
         self.sort = Sort.new
         self.update_available = false
         self.update_version = nil
@@ -81,6 +90,7 @@ module LogBench
 
       def clear_requests_filter
         main_filter.clear
+        request_filters.each_value(&:clear)
         self.selected = 0
         self.scroll_offset = 0
       end
@@ -156,6 +166,7 @@ module LogBench
       def enter_filter_mode
         if left_pane_focused?
           main_filter.enter_mode
+          self.active_request_filter_column ||= :path
         else
           detail_filter.enter_mode
         end
@@ -168,7 +179,7 @@ module LogBench
 
       def add_to_filter(char)
         if main_filter.active?
-          main_filter.add_character(char)
+          active_request_filter.add_character(char)
         elsif detail_filter.active?
           detail_filter.add_character(char)
         end
@@ -176,7 +187,7 @@ module LogBench
 
       def backspace_filter
         if main_filter.active?
-          main_filter.remove_character
+          active_request_filter.remove_character
         elsif detail_filter.active?
           detail_filter.remove_character
         end
@@ -190,19 +201,34 @@ module LogBench
         detail_filter.active?
       end
 
+      def request_filter_columns
+        REQUEST_FILTER_COLUMNS
+      end
+
+      def request_filter_for(column)
+        request_filters[column]
+      end
+
+      def select_request_filter_column(column)
+        return unless request_filter_columns.include?(column)
+
+        self.active_request_filter_column = column
+      end
+
+      def next_request_filter_column
+        switch_request_filter_column(1)
+      end
+
+      def previous_request_filter_column
+        switch_request_filter_column(-1)
+      end
+
+      def request_filters_present?
+        request_filters.values.any?(&:present?) || main_filter.present?
+      end
+
       def filtered_requests
-        filtered = if main_filter.present?
-          requests.select do |req|
-            main_filter.matches?(req.path) ||
-              main_filter.matches?(req.method) ||
-              main_filter.matches?(req.controller) ||
-              main_filter.matches?(req.action) ||
-              main_filter.matches?(req.status) ||
-              main_filter.matches?(req.request_id)
-          end
-        else
-          requests
-        end
+        filtered = requests.select { |req| request_matches_filters?(req) }
 
         sort.sort_requests(filtered)
       end
@@ -336,8 +362,89 @@ module LogBench
 
       private
 
+      attr_reader :request_filters
       attr_accessor :focused_pane, :running, :job_ids_map
-      attr_writer :main_filter, :detail_filter, :sort, :cleared_requests, :start_time, :stats, :total_queries
+      attr_writer :main_filter, :detail_filter, :sort, :cleared_requests, :start_time, :stats, :total_queries, :request_filters, :active_request_filter_column
+
+      def build_request_filters
+        REQUEST_FILTER_COLUMNS.to_h { |column| [column, Filter.new] }
+      end
+
+      def active_request_filter
+        request_filter_for(active_request_filter_column) || request_filter_for(:path)
+      end
+
+      def switch_request_filter_column(direction)
+        return unless request_filter_columns.include?(active_request_filter_column)
+
+        current_index = request_filter_columns.index(active_request_filter_column)
+        next_index = (current_index + direction) % request_filter_columns.length
+        self.active_request_filter_column = request_filter_columns[next_index]
+      end
+
+      def request_matches_filters?(request)
+        matches_legacy_main_filter?(request) && matches_column_filters?(request)
+      end
+
+      def matches_legacy_main_filter?(request)
+        return true unless main_filter.present?
+
+        main_filter.matches?(request.path) ||
+          main_filter.matches?(request.method) ||
+          main_filter.matches?(request.controller) ||
+          main_filter.matches?(request.action) ||
+          main_filter.matches?(request.status) ||
+          main_filter.matches?(request.request_id)
+      end
+
+      def matches_column_filters?(request)
+        request_filters.all? do |column, filter|
+          next true unless filter.present?
+
+          case column
+          when :method
+            filter.matches?(request.method)
+          when :path
+            filter.matches?(request.path)
+          when :status
+            numeric_filter_matches?(request.status, filter.display_text)
+          when :time
+            numeric_filter_matches?(request.duration, filter.display_text)
+          else
+            true
+          end
+        end
+      end
+
+      def numeric_filter_matches?(value, filter_text)
+        return true if filter_text.nil?
+
+        expression = filter_text.strip
+        return true if expression.empty?
+        return true if expression.match?(NUMERIC_COMPARATOR_ONLY_REGEX)
+        return false if value.nil?
+
+        if (comparison = expression.match(NUMERIC_COMPARATOR_REGEX))
+          compare_numeric(value.to_f, comparison[1], comparison[2].to_f)
+        elsif (range = expression.match(NUMERIC_RANGE_REGEX))
+          min_value, max_value = [range[1].to_f, range[2].to_f].minmax
+          value.to_f.between?(min_value, max_value)
+        elsif expression.match?(NUMERIC_VALUE_REGEX)
+          (value.to_f - expression.to_f).abs <= NUMERIC_COMPARISON_EPSILON
+        else
+          value.to_s.downcase.include?(expression.downcase)
+        end
+      end
+
+      def compare_numeric(value, operator, threshold)
+        case operator
+        when "<" then value < threshold
+        when "<=" then value <= threshold
+        when ">" then value > threshold
+        when ">=" then value >= threshold
+        else false
+        end
+      end
     end
   end
 end

--- a/lib/log_bench/app/state.rb
+++ b/lib/log_bench/app/state.rb
@@ -147,6 +147,18 @@ module LogBench
         sort.cycle
       end
 
+      def toggle_request_sort(column)
+        return unless sort.toggle_column(column)
+
+        self.auto_scroll = false
+        self.selected = 0
+        self.scroll_offset = 0
+      end
+
+      def sort_arrow_for_column(column)
+        sort.sort_arrow_for_column(column)
+      end
+
       def switch_to_left_pane
         self.focused_pane = :left
       end

--- a/test/test_input_handler_filter.rb
+++ b/test/test_input_handler_filter.rb
@@ -14,18 +14,50 @@ class TestInputHandlerFilter < Minitest::Test
   def test_backspace_ascii_127_removes_character
     @input_handler.send(:handle_filter_input, 127)
 
-    assert_equal "a", @state.main_filter.display_text
+    assert_equal "a", @state.request_filter_for(:path).display_text
   end
 
   def test_backspace_ctrl_h_removes_character
     @input_handler.send(:handle_filter_input, 8)
 
-    assert_equal "a", @state.main_filter.display_text
+    assert_equal "a", @state.request_filter_for(:path).display_text
   end
 
   def test_backspace_key_backspace_removes_character
     @input_handler.send(:handle_filter_input, Curses::KEY_BACKSPACE)
 
-    assert_equal "a", @state.main_filter.display_text
+    assert_equal "a", @state.request_filter_for(:path).display_text
+  end
+
+  def test_right_arrow_switches_active_request_filter_column
+    assert_equal :path, @state.active_request_filter_column
+
+    @input_handler.send(:handle_filter_input, Curses::KEY_RIGHT)
+
+    assert_equal :status, @state.active_request_filter_column
+  end
+
+  def test_left_arrow_switches_active_request_filter_column
+    assert_equal :path, @state.active_request_filter_column
+
+    @input_handler.send(:handle_filter_input, Curses::KEY_LEFT)
+
+    assert_equal :method, @state.active_request_filter_column
+  end
+
+  def test_shift_tab_switches_active_request_filter_column_backwards
+    assert_equal :path, @state.active_request_filter_column
+
+    @input_handler.send(:handle_filter_input, 353)
+
+    assert_equal :method, @state.active_request_filter_column
+  end
+
+  def test_tab_cycles_active_request_filter_column
+    @state.select_request_filter_column(:time)
+
+    @input_handler.send(:handle_filter_input, 9)
+
+    assert_equal :method, @state.active_request_filter_column
   end
 end

--- a/test/test_mouse_handler_filter_clicks.rb
+++ b/test/test_mouse_handler_filter_clicks.rb
@@ -37,6 +37,10 @@ class TestMouseHandlerFilterClicks < Minitest::Test
 
     @mouse_handler.send(:handle_mouse_click, status_header_x, 6)
     assert_equal "↑", @state.sort_arrow_for_column(:status)
+
+    @mouse_handler.send(:handle_mouse_click, status_header_x, 6)
+    assert_nil @state.sort_arrow_for_column(:status)
+    assert_equal "TIMESTAMP ASC", @state.sort.display_name
   end
 
   def test_clicking_path_header_does_not_change_sort

--- a/test/test_mouse_handler_filter_clicks.rb
+++ b/test/test_mouse_handler_filter_clicks.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestMouseHandlerFilterClicks < Minitest::Test
+  TestScreen = Struct.new(:panel_width)
+
+  def setup
+    @state = test_state
+    collection = LogBench::Log::Collection.new(TestFixtures.simple_log_lines)
+    @state.requests = collection.requests
+    @screen = TestScreen.new(50)
+    @mouse_handler = LogBench::App::MouseHandler.new(@state, @screen)
+  end
+
+  def test_clicking_filter_row_selects_column_and_enters_filter_mode
+    @state.switch_to_right_pane
+    refute @state.filter_mode
+
+    # y = 5 (header) + 2 (RequestList::FILTER_ROW_Y)
+    status_x = @screen.panel_width - 13
+    @mouse_handler.send(:handle_mouse_click, status_x, 7)
+
+    assert @state.left_pane_focused?
+    assert @state.filter_mode
+    assert_equal :status, @state.active_request_filter_column
+  end
+
+  def test_clicking_time_filter_area_selects_time_column
+    @state.switch_to_right_pane
+    refute @state.filter_mode
+
+    # y = 5 (header) + 2 (RequestList::FILTER_ROW_Y)
+    time_x = @screen.panel_width - 3
+    @mouse_handler.send(:handle_mouse_click, time_x, 7)
+
+    assert @state.left_pane_focused?
+    assert @state.filter_mode
+    assert_equal :time, @state.active_request_filter_column
+  end
+
+  def test_clicking_first_request_row_selects_request
+    @state.selected = 1
+
+    # y = 5 (header) + 3 (RequestList::ROWS_START_Y)
+    @mouse_handler.send(:handle_mouse_click, 10, 8)
+
+    assert_equal 0, @state.selected
+  end
+
+  def test_clicking_second_request_row_selects_second_request
+    @state.selected = 0
+
+    # second request row is first request row + 1
+    @mouse_handler.send(:handle_mouse_click, 10, 9)
+
+    assert_equal 1, @state.selected
+  end
+end

--- a/test/test_mouse_handler_filter_clicks.rb
+++ b/test/test_mouse_handler_filter_clicks.rb
@@ -26,6 +26,30 @@ class TestMouseHandlerFilterClicks < Minitest::Test
     assert_equal :status, @state.active_request_filter_column
   end
 
+  def test_clicking_status_header_toggles_status_sort_direction
+    @state.switch_to_right_pane
+
+    # y = 5 (header) + 1 (RequestList::COLUMN_HEADER_Y)
+    status_header_x = 34
+    @mouse_handler.send(:handle_mouse_click, status_header_x, 6)
+
+    assert_equal "↓", @state.sort_arrow_for_column(:status)
+
+    @mouse_handler.send(:handle_mouse_click, status_header_x, 6)
+    assert_equal "↑", @state.sort_arrow_for_column(:status)
+  end
+
+  def test_clicking_path_header_does_not_change_sort
+    initial_display_name = @state.sort.display_name
+
+    # y = 5 (header) + 1 (RequestList::COLUMN_HEADER_Y)
+    path_header_x = 20
+    @mouse_handler.send(:handle_mouse_click, path_header_x, 6)
+
+    assert_equal initial_display_name, @state.sort.display_name
+    assert_nil @state.sort_arrow_for_column(:path)
+  end
+
   def test_clicking_time_filter_area_selects_time_column
     @state.switch_to_right_pane
     refute @state.filter_mode

--- a/test/test_request_column_filters.rb
+++ b/test/test_request_column_filters.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestRequestColumnFilters < Minitest::Test
+  def setup
+    @state = test_state
+    collection = LogBench::Log::Collection.new(TestFixtures.simple_log_lines)
+    @state.requests = collection.requests
+  end
+
+  def test_filters_by_status_comparison
+    set_filter(:status, ">200")
+
+    filtered = @state.filtered_requests
+    assert_equal 1, filtered.size
+    assert_equal 201, filtered.first.status
+  end
+
+  def test_filters_by_time_comparison
+    set_filter(:time, "<100")
+
+    filtered = @state.filtered_requests
+    assert_equal 1, filtered.size
+    assert_equal "GET", filtered.first.method
+  end
+
+  def test_filters_by_numeric_range
+    set_filter(:status, "200-200")
+
+    filtered = @state.filtered_requests
+    assert_equal 1, filtered.size
+    assert_equal 200, filtered.first.status
+  end
+
+  def test_ignores_operator_only_filter_for_status
+    set_filter(:status, ">")
+    assert_equal 2, @state.filtered_requests.size
+
+    set_filter(:status, "<=")
+    assert_equal 2, @state.filtered_requests.size
+  end
+
+  def test_ignores_operator_only_filter_for_time
+    set_filter(:time, "<")
+    assert_equal 2, @state.filtered_requests.size
+
+    set_filter(:time, ">=")
+    assert_equal 2, @state.filtered_requests.size
+  end
+
+  def test_applies_multiple_column_filters
+    set_filter(:method, "post")
+    set_filter(:time, ">=120")
+
+    filtered = @state.filtered_requests
+    assert_equal 1, filtered.size
+    assert_equal "POST", filtered.first.method
+    assert_operator filtered.first.duration, :>=, 120
+  end
+
+  def test_clear_filter_clears_all_request_column_filters
+    @state.switch_to_left_pane
+    set_filter(:method, "get")
+    set_filter(:time, ">10")
+    assert @state.request_filters_present?
+
+    @state.clear_filter
+
+    refute @state.request_filters_present?
+    assert_equal 2, @state.filtered_requests.size
+  end
+
+  private
+
+  def set_filter(column, expression)
+    filter = @state.request_filter_for(column)
+    filter.clear
+    expression.each_char { |char| filter.add_character(char) }
+  end
+end

--- a/test/test_sort_toggle.rb
+++ b/test/test_sort_toggle.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestSortToggle < Minitest::Test
+  def setup
+    @state = test_state
+    collection = LogBench::Log::Collection.new(TestFixtures.simple_log_lines)
+    @state.requests = collection.requests
+  end
+
+  def test_toggle_status_sort_direction
+    @state.toggle_request_sort(:status)
+
+    assert_equal "↓", @state.sort_arrow_for_column(:status)
+    assert_equal 201, @state.filtered_requests.first.status
+
+    @state.toggle_request_sort(:status)
+
+    assert_equal "↑", @state.sort_arrow_for_column(:status)
+    assert_equal 200, @state.filtered_requests.first.status
+  end
+
+  def test_toggle_time_sort_direction
+    max_duration = @state.requests.map(&:duration).max
+    min_duration = @state.requests.map(&:duration).min
+
+    @state.toggle_request_sort(:time)
+
+    assert_equal "↓", @state.sort_arrow_for_column(:time)
+    assert_equal max_duration, @state.filtered_requests.first.duration
+
+    @state.toggle_request_sort(:time)
+
+    assert_equal "↑", @state.sort_arrow_for_column(:time)
+    assert_equal min_duration, @state.filtered_requests.first.duration
+  end
+
+  def test_path_sort_is_ignored
+    initial_display_name = @state.sort.display_name
+
+    @state.toggle_request_sort(:path)
+
+    assert_equal initial_display_name, @state.sort.display_name
+    assert_nil @state.sort_arrow_for_column(:path)
+  end
+end

--- a/test/test_sort_toggle.rb
+++ b/test/test_sort_toggle.rb
@@ -19,6 +19,11 @@ class TestSortToggle < Minitest::Test
 
     assert_equal "↑", @state.sort_arrow_for_column(:status)
     assert_equal 200, @state.filtered_requests.first.status
+
+    @state.toggle_request_sort(:status)
+
+    assert_nil @state.sort_arrow_for_column(:status)
+    assert_equal "TIMESTAMP ASC", @state.sort.display_name
   end
 
   def test_toggle_time_sort_direction
@@ -34,6 +39,11 @@ class TestSortToggle < Minitest::Test
 
     assert_equal "↑", @state.sort_arrow_for_column(:time)
     assert_equal min_duration, @state.filtered_requests.first.duration
+
+    @state.toggle_request_sort(:time)
+
+    assert_nil @state.sort_arrow_for_column(:time)
+    assert_equal "TIMESTAMP ASC", @state.sort.display_name
   end
 
   def test_path_sort_is_ignored


### PR DESCRIPTION

<img width="1197" height="716" alt="Screenshot From 2026-02-17 17-39-39" src="https://github.com/user-attachments/assets/a676845c-7763-4d25-849f-1e1ed2289acd" />

## Summary

This PR introduces a dedicated per-column filtering workflow in the request
list and follows through with keyboard/mouse UX, filter expression behavior,
renderer cleanup, and request-header mouse sorting improvements.

## What changed

### 1) Column filter state and matching
- Added per-column request filters in `State` for:
  - `method`, `path`, `status`, `time`
- Kept compatibility with the legacy main filter path.
- Added numeric expression matching for `status` and `time`:
  - comparators: `>`, `>=`, `<`, `<=`
  - exact numbers
  - ranges like `50-100`
- Important UX rule from discussion:
  - operator-only input (`>`, `<`, `>=`, `<=`) is treated as **no-op**
    (ignored), so incomplete expressions do not hide all rows.

### 2) Filter mode keyboard behavior
- Added column navigation keys while in filter mode:
  - left/right arrows
  - `Tab` / `Shift+Tab`
- Backspace behavior remains robust in filter mode.

### 3) Dedicated filter row + mouse support
- Replaced header-inline filtering with a dedicated row under column headers.
- Shows instruction text when filters are inactive:
  - `Press f to start filtering, operators allowed: > >= < <= 50-100`
- Renders per-column inputs when filter mode is active or filters are present.
- Added blinking active cursor in the selected filter cell.
- Added filter-row mouse click support to select column and enter filter mode.

### 4) Visual and cleanup improvements
- Removed temporary/testing palette UI and dead palette setup code.
- Consolidated layout offsets used by renderer and mouse hit-testing to avoid
  drift.
- Replaced renderer color magic numbers with semantic constants in:
  - `renderer/ansi.rb`
  - `renderer/details.rb`
  - `renderer/scrollbar.rb`
  - plus related usage updates in header/request list.

### 5) Request header sorting via mouse clicks
- Clicking sortable request headers toggles sorting for `METHOD`, `STATUS`,
  and `TIME`.
- `PATH` remains intentionally unsortable.
- Active sorted column shows arrow direction in the header.
- Sort is tri-state per clickable column:
  - first click: default direction
  - second click: reversed direction
  - third click: clears column arrow and resets to `TIMESTAMP ASC`

## Tests

Added/updated tests:
- `test/test_request_column_filters.rb`
- `test/test_input_handler_filter.rb`
- `test/test_mouse_handler_filter_clicks.rb`
- `test/test_sort_toggle.rb`

Validation run:
- `bundle exec standardrb`
- `bundle exec rake test`

Both pass locally.
